### PR TITLE
Add security header middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ To set up a local instance of BGC Atlas, follow these steps:
 BGC Atlas is built with the following main dependencies:
 
 - [Express.js](https://expressjs.com/) - Web framework
+- [Helmet](https://helmetjs.github.io/) - Security headers
 - [Pug](https://pugjs.org/) - Template engine
 - [PostgreSQL](https://www.postgresql.org/) - Database
 - [Leaflet](https://leafletjs.com/) - Interactive maps

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 const geoip = require('geoip-lite');
+const helmet = require('helmet');
 
 
 // Import database configuration
@@ -12,6 +13,7 @@ require('./config/database');
 const indexRouter = require('./routes/index');
 
 const app = express();
+app.use(helmet());
 
 const ultraDeepSoilRouter = require('./routes/ultraDeepSoilRouter');
 const monthlySoilRouter = require('./routes/monthlySoilRouter');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express-sitemap": "^1.8.0",
         "fs-extra": "^11.3.0",
         "geoip-lite": "^1.4.7",
+        "helmet": "^8.1.0",
         "http-errors": "~1.6.3",
         "jquery": "^3.6.4",
         "leaflet": "^1.9.3",
@@ -984,6 +985,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express-sitemap": "^1.8.0",
     "fs-extra": "^11.3.0",
     "geoip-lite": "^1.4.7",
+    "helmet": "^8.1.0",
     "http-errors": "~1.6.3",
     "jquery": "^3.6.4",
     "leaflet": "^1.9.3",


### PR DESCRIPTION
## Summary
- install `helmet` for basic security header middleware
- include `helmet` in runtime dependencies
- apply `helmet` middleware in `app.js`
- document dependency in README

## Testing
- `npm install helmet --save`

------
https://chatgpt.com/codex/tasks/task_e_68409867bbdc833398852c08af9fd5c6