### PR TITLE
Sanitize uploaded filenames with uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "multer": "^2.0.1",
         "node-cache": "^5.1.2",
         "pg": "^8.10.0",
-        "pug": "^3.0.3"
+        "pug": "^3.0.3",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -5435,6 +5436,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "leaflet.markercluster": "^1.5.3",
     "morgan": "~1.9.1",
     "multer": "^2.0.1",
+    "uuid": "^9.0.1",
     "node-cache": "^5.1.2",
     "pg": "^8.10.0",
     "pug": "^3.0.3"

--- a/routes/index.js
+++ b/routes/index.js
@@ -106,6 +106,8 @@ router.use(bodyParser.urlencoded({ extended: true }));
 // const storage = multer.memoryStorage(); // Store files in memory
 // const upload = multer({ storage: storage });
 
+const { v4: uuidv4 } = require('uuid');
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     // Create the upload directory once per request
@@ -116,7 +118,10 @@ const storage = multer.diskStorage({
     cb(null, req.uploadDir);
   },
   filename: function (req, file, cb) {
-    cb(null, file.originalname); // Use the original filename
+    let safeName = path.basename(file.originalname);
+    safeName = safeName.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const uniqueName = `${uuidv4()}_${safeName}`;
+    cb(null, uniqueName);
   }
 });
 


### PR DESCRIPTION
## Summary
- sanitize uploaded file names in Multer storage
- add uuid package for unique name generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409f0d0e4c8333a116510571b31470