### PR TITLE
Fix path traversal in searchService

### DIFF
--- a/tests/searchService.test.js
+++ b/tests/searchService.test.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => ({
+    stderr: { on: jest.fn() },
+    stdout: { on: jest.fn() },
+    on: jest.fn((event, cb) => { if (event === 'close') cb(0); })
+  }))
+}));
+
+const { sanitizeDirectoryName, getMembership } = require('../services/searchService');
+const { spawn } = require('child_process');
+
+describe('sanitizeDirectoryName', () => {
+  it('allows valid names', () => {
+    expect(sanitizeDirectoryName('abc123')).toBe('abc123');
+    expect(sanitizeDirectoryName('A_B-c')).toBe('A_B-c');
+  });
+
+  it('rejects names with invalid characters', () => {
+    expect(() => sanitizeDirectoryName('../evil')).toThrow();
+    expect(() => sanitizeDirectoryName('some/evil')).toThrow();
+    expect(() => sanitizeDirectoryName('bad..id')).toThrow();
+  });
+});
+
+describe('getMembership', () => {
+  it('rejects invalid report ids before spawning', async () => {
+    await expect(getMembership('../evil')).rejects.toThrow();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('spawns sqlite3 with sanitized path', async () => {
+    await getMembership('validID');
+    const expected = path.join('/vol/compl_bgcs_bigslice_def_t300/reports', 'validID', 'data.db');
+    expect(spawn).toHaveBeenCalledWith('sqlite3', [expected, expect.any(String)]);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize report IDs before building sqlite3 paths
- add tests for sanitization and getMembership

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409f1d84448333af2973e63a8409f1