### PR TITLE
Add file type filter and size limit

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -120,7 +120,18 @@ const storage = multer.diskStorage({
   }
 });
 
-const upload = multer({ storage: storage }).array('file', 20); // Limit to 20 files
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: function (req, file, cb) {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (ext === '.gbk' || ext === '.genbank') {
+      cb(null, true);
+    } else {
+      cb(new Error('Only .gbk or .genbank files are allowed'));
+    }
+  }
+}).array('file', 20); // Limit to 20 files
 
 let clients = [];
 
@@ -154,7 +165,8 @@ router.post('/upload', (req, res) => {
   upload(req, res, async (err) => {
     if (err) {
       sendEvent({ status: 'Error', message: err.message });
-      return res.status(500).json({ error: err.message });
+      const status = err.message.includes('.gbk') || err.message.includes('.genbank') ? 400 : 500;
+      return res.status(status).json({ error: err.message });
     }
 
     try {


### PR DESCRIPTION
## Summary
- restrict uploads to .gbk or .genbank files and max 5MB size
- return 400 Bad Request when upload uses disallowed file type

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a14f875c8333963fdb6ada3ad0e9