### PR TITLE
Improve plot visuals

### DIFF
--- a/public/javascripts/sunburst.js
+++ b/public/javascripts/sunburst.js
@@ -67,8 +67,8 @@ function render(data, targetElement) {
     const spec = {
         "$schema": "https://vega.github.io/schema/vega/v5.json",
         "description": "A hierarchical view of biome tree distribution with zoom functionality and tooltip on click.",
-        "width": 300,
-        "height": 300,
+        "width": 350,
+        "height": 350,
         "padding": 5,
         "autosize": "pad",
 
@@ -137,7 +137,7 @@ function render(data, targetElement) {
                 "name": "color",
                 "type": "ordinal",
                 "domain": {"data": "tree", "field": "levelId"},
-                "range": {"scheme": "spectral"}
+                "range": {"scheme": "category20b"}
             }
         ],
 
@@ -147,7 +147,7 @@ function render(data, targetElement) {
                 "fill": "color",
                 "title": "Biomes",
                 "orient": "right",
-                "columns": 2,  // You can adjust the number of columns to fit your design
+                "columns": 3,
                 "labelLimit": 0
             }
         ],

--- a/views/bgcs.pug
+++ b/views/bgcs.pug
@@ -227,10 +227,10 @@ block scripts
                     const ctx = canvas.getContext('2d');
                     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-                    // Create a gradient color scheme
+                    // Create a gradient color scheme with a smoother transition
                     const gradient = ctx.createLinearGradient(0, 0, 0, 400);
-                    gradient.addColorStop(0, 'rgba(255, 102, 102, 0.8)');    // Lighter red (top)
-                    gradient.addColorStop(1, 'rgba(204, 51, 51, 0.6)');      // Darker red (bottom)
+                    gradient.addColorStop(0, 'rgba(255, 183, 77, 0.9)');    // light orange
+                    gradient.addColorStop(1, 'rgba(251, 140, 0, 0.7)');     // dark orange
 
                     const chart = new Chart(ctx, {
                         type: 'bar',
@@ -259,6 +259,7 @@ block scripts
                             },
                             plugins: {
                                 legend: {
+                                    position: 'top',
                                     labels: {
                                         font: {
                                             size: 14,
@@ -354,8 +355,8 @@ block scripts
 
                     // Create a gradient color scheme - using a different shade for this chart
                     const gradient = ctx.createLinearGradient(0, 0, 0, 400);
-                    gradient.addColorStop(0, 'rgba(102, 153, 255, 0.8)');    // Lighter blue (top)
-                    gradient.addColorStop(1, 'rgba(51, 102, 204, 0.6)');     // Darker blue (bottom)
+                    gradient.addColorStop(0, 'rgba(102, 187, 106, 0.9)');  // light green
+                    gradient.addColorStop(1, 'rgba(56, 142, 60, 0.7)');    // dark green
 
                     const chart = new Chart(ctx, {
                         type: 'bar',
@@ -384,6 +385,7 @@ block scripts
                             },
                             plugins: {
                                 legend: {
+                                    position: 'top',
                                     labels: {
                                         font: {
                                             size: 14,

--- a/views/gcfs.pug
+++ b/views/gcfs.pug
@@ -102,6 +102,11 @@ block scripts
                     const ctx = canvas.getContext('2d');
                     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+                    // Create a gradient color scheme for improved visuals
+                    const gradient = ctx.createLinearGradient(0, 0, 0, 400);
+                    gradient.addColorStop(0, 'rgba(171, 71, 188, 0.9)'); // light purple
+                    gradient.addColorStop(1, 'rgba(123, 31, 162, 0.7)');  // dark purple
+
                     const chart = new Chart(ctx, {
                         type: 'bar',
                         data: {
@@ -110,16 +115,45 @@ block scripts
                                 {
                                     label: 'GCFs by Category',
                                     data: data,
-                                    backgroundColor: 'rgba(54, 162, 235, 0.2)',
-                                    borderColor: 'rgba(54, 162, 235, 1)',
-                                    borderWidth: 1,
+                                    backgroundColor: gradient,
+                                    borderColor: 'rgba(123, 31, 162, 1)',
+                                    borderWidth: 2,
+                                    borderRadius: 5,
+                                    hoverBackgroundColor: 'rgba(171, 71, 188, 1)',
+                                    hoverBorderColor: 'rgba(74, 20, 140, 1)',
+                                    hoverBorderWidth: 2,
                                 },
                             ],
                         },
                         options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            animation: {
+                                duration: 1000,
+                                easing: 'easeOutQuart'
+                            },
+                            plugins: {
+                                legend: {
+                                    position: 'top',
+                                    labels: {
+                                        font: {
+                                            size: 14,
+                                            weight: 'bold'
+                                        }
+                                    }
+                                }
+                            },
                             scales: {
                                 y: {
-                                    beginAtZero: true
+                                    beginAtZero: true,
+                                    grid: {
+                                        color: 'rgba(200, 200, 200, 0.3)'
+                                    },
+                                    ticks: {
+                                        font: {
+                                            weight: 'bold'
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -145,6 +179,11 @@ block scripts
                     const ctx = canvas.getContext('2d');
                     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+                    // Create a gradient color scheme
+                    const gradient = ctx.createLinearGradient(0, 0, 0, 400);
+                    gradient.addColorStop(0, 'rgba(77, 182, 172, 0.9)');  // light teal
+                    gradient.addColorStop(1, 'rgba(38, 166, 154, 0.7)');   // dark teal
+
                     const chart = new Chart(ctx, {
                         type: 'bar',
                         data: {
@@ -153,22 +192,57 @@ block scripts
                                 {
                                     label: 'Histogram of BGC counts per GCF',
                                     data: data,
-                                    backgroundColor: 'rgba(54, 162, 235, 0.2)',
-                                    borderColor: 'rgba(54, 162, 235, 1)',
-                                    borderWidth: 1,
+                                    backgroundColor: gradient,
+                                    borderColor: 'rgba(0, 131, 143, 1)',
+                                    borderWidth: 2,
+                                    borderRadius: 5,
+                                    hoverBackgroundColor: 'rgba(77, 182, 172, 1)',
+                                    hoverBorderColor: 'rgba(0, 77, 64, 1)',
+                                    hoverBorderWidth: 2,
                                 },
                             ],
                         },
                         options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            animation: {
+                                duration: 1000,
+                                easing: 'easeOutQuart'
+                            },
+                            plugins: {
+                                legend: {
+                                    position: 'top',
+                                    labels: {
+                                        font: {
+                                            size: 14,
+                                            weight: 'bold'
+                                        }
+                                    }
+                                }
+                            },
                             scales: {
                                 x: {
                                     ticks: {
                                         autoSkip: false,
+                                        font: {
+                                            weight: 'bold'
+                                        }
+                                    },
+                                    grid: {
+                                        display: false
                                     }
                                 },
                                 y: {
                                     type: 'logarithmic',
-                                    beginAtZero: true
+                                    beginAtZero: true,
+                                    grid: {
+                                        color: 'rgba(200, 200, 200, 0.3)'
+                                    },
+                                    ticks: {
+                                        font: {
+                                            weight: 'bold'
+                                        }
+                                    }
                                 }
                             }
 
@@ -265,7 +339,7 @@ block scripts
                     return;
                 }
                 new Chart(ctx, {
-                    type: 'pie',
+                    type: 'doughnut',
                     data: {
                         labels: labels, // Labels are needed for the tooltip
                         datasets: [{
@@ -277,6 +351,7 @@ block scripts
                     },
                     options: {
                         responsive: true,
+                        cutout: '50%',
                         plugins: {
                             legend: {
                                 display: false // Hide the legend labels


### PR DESCRIPTION
## Summary
- tweak color scheme of the sunburst view and enlarge the figure
- use gradients and nicer legends for all bar charts
- show doughnut style pie charts for GCF tables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840af87f26483339782fcd10a285b22