### PR TITLE
Add taxonomy to BGC table

### DIFF
--- a/tests/searchService.test.js
+++ b/tests/searchService.test.js
@@ -8,6 +8,8 @@ jest.mock('child_process', () => ({
   }))
 }));
 
+process.env.REPORTS_DIR = '/tmp';
+
 const { sanitizeDirectoryName, getMembership } = require('../services/searchService');
 const { spawn } = require('child_process');
 
@@ -32,7 +34,7 @@ describe('getMembership', () => {
 
   it('spawns sqlite3 with sanitized path', async () => {
     await getMembership('validID');
-    const expected = path.join('/vol/compl_bgcs_bigslice_def_t300/reports', 'validID', 'data.db');
+    const expected = path.join(process.env.REPORTS_DIR, 'validID', 'data.db');
     expect(spawn).toHaveBeenCalledWith('sqlite3', [expected, expect.any(String)]);
   });
 });

--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -10,6 +10,9 @@ jest.mock('child_process', () => ({
   spawn: jest.fn()
 }));
 
+process.env.SEARCH_UPLOADS_DIR = '/tmp';
+process.env.SEARCH_SCRIPT_PATH = '/bin/true';
+
 const { createTimestampedDirectory, processUploadedFiles } = require('../services/searchService');
 
 describe('createTimestampedDirectory', () => {

--- a/views/bgcs.pug
+++ b/views/bgcs.pug
@@ -515,6 +515,7 @@ block scripts
                 columns: [
                     {data: 'region_id', name: 'BGC ID', title: 'BGC ID', type: 'num'},
                     {data: 'assembly', name: 'Assembly', title: 'Assembly', type: 'string'},
+                    {data: 'taxon_name', name: 'Taxon', title: 'Taxon', type: 'string'},
                     {data: 'product_categories', name: 'Category', title: 'Category', type: 'string'},
                     {data: 'products', name: 'Product', title: 'Product', type: 'string'},
                     {data: 'longest_biome', name: 'Biome', title: 'Biome', type: 'string'},
@@ -554,7 +555,7 @@ block scripts
                         var rowNum = rowNumCell.html();
                         var paddedRowNum = rowNum.padStart(9, '0');
                         rowNumCell.html("BGC_" + paddedRowNum);
-                        var biomeCell = $(row).find('td').eq(4);
+                        var biomeCell = $(row).find('td').eq(5);
                         biomeCell.html(biomeCell.html().replaceAll('root:', ''));
                         var assemblyCell = $(row).find('td').eq(1);
                         var assemblyID = assemblyCell.html();
@@ -565,7 +566,7 @@ block scripts
                         bgcCell.html('<a href="https://bgc-atlas.cs.uni-tuebingen.de/antismash?dataset=' + assemblyID + '&anchor=' + data.anchor + '" target="_blank">' + bgcCell.html() + '</a>');
 
                         //bgcCell.html('<a href="https://bgc-atlas.ziemertlab.com/datasets/' + data.assembly + '/antismash/index.html#' + data.anchor + '" target="_blank">' + bgcCell.html() + '</a>');
-                        var gcfCell = $(row).find('td').eq(6);
+                        var gcfCell = $(row).find('td').eq(7);
                         gcfCell.html('<a href="/bgcs?gcf=' + gcfCell.html() + '" target="_blank">' + gcfCell.html() + '</a>');
                     }
                 },
@@ -588,60 +589,66 @@ block scripts
                                 </span>
                             `);
                     $(thead).find('th').eq(2).html(`
+                                Taxon
+                                <span class="info-icon" data-bs-toggle="tooltip" title="Taxonomic name associated with the region.">
+                                    <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
+                                </span>
+                            `);
+                    $(thead).find('th').eq(3).html(`
                                 Product Category
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Product category of the BGC.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(3).html(`
+                    $(thead).find('th').eq(4).html(`
                                 Product
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Product type of the BGC.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(4).html(`
+                    $(thead).find('th').eq(5).html(`
                                 Biome
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Biome annotation of the sample.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(5).html(`
+                    $(thead).find('th').eq(6).html(`
                                 Length
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Length of the BGC.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(6).html(`
+                    $(thead).find('th').eq(7).html(`
                                 GCF
                                 <span class="info-icon" data-bs-toggle="tooltip" title="GCF identifier. Clicking this opens the GCF page.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(7).html(`
+                    $(thead).find('th').eq(8).html(`
                                 Membership Value
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Membership value of the BGC to its assigned GCF. Values above 0.4 mean that the BGC is a putative member of the GCF.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(8).html(`
+                    $(thead).find('th').eq(9).html(`
                                 Core
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Core BGCs are those that are annotated as complete by antiSMASH and used to construct the initial clustering of BGCs into GCFs.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(9).html(`
+                    $(thead).find('th').eq(10).html(`
                                 Contig Edge
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Indicates whether the BGC is located at the edge of a contig.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(10).html(`
+                    $(thead).find('th').eq(11).html(`
                                 Contig
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Name of the contig where the BGC is located.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                 </span>
                             `);
-                    $(thead).find('th').eq(11).html(`
+                    $(thead).find('th').eq(12).html(`
                                 Region#
                                 <span class="info-icon" data-bs-toggle="tooltip" title="Region number of the BGC.">
                                     <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />


### PR DESCRIPTION
## Summary
- join taxonomy tables in BGC table queries
- expose `taxon_name` column from the backend
- show taxon column in the BGC table UI
- update tests for new joins and configure env vars for search tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c2025bc08333b9a6370b7a9cb3ed