### PR TITLE
Add taxonomy aggregation for GCF table

### DIFF
--- a/tests/bgcService.test.js
+++ b/tests/bgcService.test.js
@@ -1,9 +1,9 @@
 const cacheService = require('../services/cacheService');
-const { client } = require('../config/database');
+const { client, pool } = require('../config/database');
 
 jest.mock('../config/database', () => ({
   client: { query: jest.fn() },
-  pool: {}
+  pool: { query: jest.fn() }
 }));
 
 jest.mock('../services/cacheService', () => ({
@@ -23,5 +23,21 @@ describe('bgcService.getBgcInfo', () => {
     expect(result).toEqual(rows);
     expect(client.query).toHaveBeenCalledTimes(1);
     expect(cacheService.getOrFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bgcService.getGcfTable', () => {
+  it('aggregates taxonomy information', async () => {
+    const rows = [{ gcf_id: 1, core_taxa: 'GenusA (2)', all_taxa: 'GenusA (2), GenusB (1)' }];
+    pool.query.mockResolvedValue({ rows });
+    cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
+
+    const result = await bgcService.getGcfTable();
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const sql = pool.query.mock.calls[0][0];
+    expect(sql).toMatch(/core_taxa/);
+    expect(sql).toMatch(/all_taxa/);
+    expect(result).toEqual(rows);
   });
 });

--- a/tests/searchService.test.js
+++ b/tests/searchService.test.js
@@ -11,6 +11,8 @@ jest.mock('child_process', () => ({
 const { sanitizeDirectoryName, getMembership } = require('../services/searchService');
 const { spawn } = require('child_process');
 
+process.env.REPORTS_DIR = '/vol/compl_bgcs_bigslice_def_t300/reports';
+
 describe('sanitizeDirectoryName', () => {
   it('allows valid names', () => {
     expect(sanitizeDirectoryName('abc123')).toBe('abc123');

--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -12,6 +12,9 @@ jest.mock('child_process', () => ({
 
 const { createTimestampedDirectory, processUploadedFiles } = require('../services/searchService');
 
+process.env.SEARCH_UPLOADS_DIR = '/tmp/uploads';
+process.env.SEARCH_SCRIPT_PATH = '/bin/echo';
+
 describe('createTimestampedDirectory', () => {
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockReturnValue(1234567890000);

--- a/views/gcfs.pug
+++ b/views/gcfs.pug
@@ -481,6 +481,26 @@ block scripts
                             return data;
                         }
                     },
+                    {
+                        data: 'core_taxa',
+                        name: 'Taxa (Core)',
+                        title: 'Taxa (Core)',
+                        type: 'string',
+                        width: '17.5%',
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                if (isTextView) {
+                                    return data;
+                                } else {
+                                    const canvasId = `taxa-pie-chart-${row.gcf_id}`;
+                                    return `<div id="chart-container-${row.gcf_id}">
+                                                                <canvas id="${canvasId}" width="150" height="150"></canvas>
+                                                            </div>`;
+                                }
+                            }
+                            return data;
+                        }
+                    },
                     {data: 'num_all_regions', name: '# All BGCs', title: '# All BGCs', type: 'num', width: '5%'},
                     {
                         data: 'all_products',
@@ -502,6 +522,22 @@ block scripts
                             if (type === 'display') {
                                 const canvasId = `biomes-all-pie-chart-${row.gcf_id}`;  // Unique ID for each chart
                                 // Set the width and height of the canvas
+                                return `<div id="chart-container-${row.gcf_id}">
+                                                                <canvas id="${canvasId}" width="150" height="150"></canvas>
+                                                            </div>`;
+                            }
+                            return data;
+                        }
+                    },
+                    {
+                        data: 'all_taxa',
+                        name: 'Taxa (All)',
+                        title: 'Taxa (All)',
+                        type: 'string',
+                        width: '17.5%',
+                        render: function (data, type, row) {
+                            if (type === 'display') {
+                                const canvasId = `taxa-all-pie-chart-${row.gcf_id}`;
                                 return `<div id="chart-container-${row.gcf_id}">
                                                                 <canvas id="${canvasId}" width="150" height="150"></canvas>
                                                             </div>`;
@@ -576,6 +612,40 @@ block scripts
                             $(`#${canvasId}`).addClass('initialized');  // Mark the canvas as initialized
                             createPieChart(canvasId, labels, counts, percentages);
                         }
+
+                        canvasId = `taxa-pie-chart-${rowData.gcf_id}`;
+
+                        if (!$(`#${canvasId}`).hasClass('initialized')) {
+                            const taxData = rowData.core_taxa.split(',').map(item => {
+                                const [taxon, count] = item.trim().split(/\s*\(\s*|\s*\)\s*/);
+                                return {label: taxon, count: parseInt(count) || 0};
+                            });
+
+                            const totalCount = taxData.reduce((acc, curr) => acc + curr.count, 0);
+                            const percentages = taxData.map(b => Math.round((b.count / totalCount) * 100));
+                            const counts = taxData.map(b => b.count);
+                            const labels = taxData.map(b => b.label);
+
+                            $(`#${canvasId}`).addClass('initialized');
+                            createPieChart(canvasId, labels, counts, percentages);
+                        }
+
+                        canvasId = `taxa-all-pie-chart-${rowData.gcf_id}`;
+
+                        if (!$(`#${canvasId}`).hasClass('initialized')) {
+                            const taxData = rowData.all_taxa.split(',').map(item => {
+                                const [taxon, count] = item.trim().split(/\s*\(\s*|\s*\)\s*/);
+                                return {label: taxon, count: parseInt(count) || 0};
+                            });
+
+                            const totalCount = taxData.reduce((acc, curr) => acc + curr.count, 0);
+                            const percentages = taxData.map(b => Math.round((b.count / totalCount) * 100));
+                            const counts = taxData.map(b => b.count);
+                            const labels = taxData.map(b => b.label);
+
+                            $(`#${canvasId}`).addClass('initialized');
+                            createPieChart(canvasId, labels, counts, percentages);
+                        }
                     });
                 },
                 headerCallback: function (thead, data, start, end, display) {
@@ -604,20 +674,32 @@ block scripts
                                                     </span>
                                                 `);
                     $(thead).find('th').eq(4).html(`
+                                                    Taxa (Core)
+                                                    <span class="info-icon" data-bs-toggle="tooltip" title="Taxonomic distribution of core BGCs. Core BGCs are those that are annotated as complete by antiSMASH and used to construct the initial clustering of BGCs into GCFs.">
+                                                        <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
+                                                    </span>
+                                                `);
+                    $(thead).find('th').eq(5).html(`
                                                     # All BGCs
                                                     <span class="info-icon" data-bs-toggle="tooltip" title="Number of all BGCs in the GCF. All BGCs include both core and incomplete BGCs that are assigned to the GCF in the second step of the GCF clustering by using BiG-SLiCE's search function.">
                                                         <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                                     </span>
                                                 `);
-                    $(thead).find('th').eq(5).html(`
+                    $(thead).find('th').eq(6).html(`
                                                     Types (All)
                                                     <span class="info-icon" data-bs-toggle="tooltip" title="Types of all BGCs in the GCF. All BGCs include both core and incomplete BGCs that are assigned to the GCF in the second step of the GCF clustering by using BiG-SLiCE's search function.">
                                                         <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                                     </span>
                                                 `);
-                    $(thead).find('th').eq(6).html(`
+                    $(thead).find('th').eq(7).html(`
                                                     Biomes (All)
                                                     <span class="info-icon" data-bs-toggle="tooltip" title="Biomes where all BGCs are found. All BGCs include both core and incomplete BGCs that are assigned to the GCF in the second step of the GCF clustering by using BiG-SLiCE's search function.">
+                                                        <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
+                                                    </span>
+                                                `);
+                    $(thead).find('th').eq(8).html(`
+                                                    Taxa (All)
+                                                    <span class="info-icon" data-bs-toggle="tooltip" title="Taxonomic distribution of all BGCs. All BGCs include both core and incomplete BGCs that are assigned to the GCF in the second step of the GCF clustering by using BiG-SLiCE's search function.">
                                                         <img src="/images/info.svg" width="12" height="12" alt="Info" loading="lazy" />
                                                     </span>
                                                 `);


### PR DESCRIPTION
## Summary
- aggregate genus counts for core and all BGCs in `getGcfTable`
- expose new `core_taxa` and `all_taxa` columns in the GCF table view
- render optional pie charts summarizing taxa per GCF
- update unit tests and provide env vars for search service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c226d9448333812538cc5cbb6e49