### PR TITLE
Fix bgc service tests

### DIFF
--- a/tests/bgcService.test.js
+++ b/tests/bgcService.test.js
@@ -15,30 +15,35 @@ const bgcService = require('../services/bgcService');
 describe('bgcService.getBgcInfo', () => {
   it('returns bgc info from the database', async () => {
     const rows = [{ bgc_count: 1 }];
-    client.query.mockResolvedValue({ rows });
+    pool.query.mockResolvedValue({ rows });
     cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
 
     const result = await bgcService.getBgcInfo();
 
     expect(result).toEqual(rows);
-    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1);
     expect(cacheService.getOrFetch).toHaveBeenCalledTimes(1);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 });
 
 describe('bgcService.getGcfTable', () => {
   it('aggregates taxonomy information', async () => {
     const rows = [{ gcf_id: 1, core_taxa: 'GenusA (2)', all_taxa: 'GenusA (2), GenusB (1)' }];
-    pool.query.mockResolvedValue({ rows });
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] })
+      .mockResolvedValueOnce({ rows });
     cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
 
     const result = await bgcService.getGcfTable();
 
-    expect(pool.query).toHaveBeenCalledTimes(1);
-    const sql = pool.query.mock.calls[0][0];
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const sql = pool.query.mock.calls[1][0];
     expect(sql).toMatch(/core_taxa/);
     expect(sql).toMatch(/all_taxa/);
-    expect(result).toEqual(rows);
+    expect(result.data).toEqual(rows);
   });
 });
 


### PR DESCRIPTION
## Summary
- mock `pool.query` in `bgcService.getBgcInfo` tests
- update expectations for `getGcfTable` and clear mocks between tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840dd032eb883338869b8c581cf9972