### PR TITLE
Fix dataset sanitization

### DIFF
--- a/routes/pageRouter.js
+++ b/routes/pageRouter.js
@@ -69,11 +69,18 @@ router.get('/privacy', (req, res) => {
 });
 
 router.get('/antismash', (req, res) => {
+  const { dataset, anchor } = req.query;
+
+  // Validate dataset - only allow alphanumeric characters, dash and underscore
+  if (dataset && !/^[A-Za-z0-9_-]+$/.test(dataset)) {
+    return res.status(400).send('Invalid dataset parameter');
+  }
+
   res.render('antismash', {
-    title: 'antiSMASH Analysis', 
+    title: 'antiSMASH Analysis',
     metaDescription: 'View detailed antiSMASH analysis results for biosynthetic gene clusters in our database.',
-    dataset: req.query.dataset, 
-    anchor: req.query.anchor, 
+    dataset,
+    anchor,
     activePage: 'antismash'
   });
 });

--- a/views/antismash.pug
+++ b/views/antismash.pug
@@ -125,7 +125,7 @@ block scripts
                                             var regionAnchor = $row.find('td a').attr('href').substring(1); // e.g., "r277c1"
 
                                             // Use the dataset value passed from the parent
-                                            var dataset = '${dataset}';
+                                            var dataset = '${encodeURIComponent(dataset)}';
 
                                             // Step 1: Fetch the BGC ID from the server using dataset and regionAnchor
                                             fetch('/getBgcId?dataset=' + dataset + '&anchor=' + regionAnchor)
@@ -167,7 +167,7 @@ block scripts
         // Handle the iframe load event
         document.getElementById('contentFrame').addEventListener('load', function () {
             adjustIframeHeight(); // Adjust the height once the iframe is loaded
-            modifyIframeContent("#{dataset}");
+            modifyIframeContent("#{encodeURIComponent(dataset)}");
         });
 
         // Handle window resize to dynamically adjust iframe height


### PR DESCRIPTION
## Summary
- validate `req.query.dataset` on the server
- escape dataset variable inside `antismash` view scripts

## Testing
- `npm test` *(fails: bgcService tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd2613d88333ab5ff3a2c0b19bd9