### PR TITLE
Add validation for monthly soil parameters

### DIFF
--- a/routes/monthlySoilRouter.js
+++ b/routes/monthlySoilRouter.js
@@ -3,7 +3,7 @@ const path = require('path');
 const monthlySoilService = require('../services/monthlySoilService');
 
 const router = express.Router();
-const { BASE_DIR, FULL_AS_DIR, PRODUCT_AS_DIR } = monthlySoilService;
+const { BASE_DIR, FULL_AS_DIR, PRODUCT_AS_DIR, NAME_REGEX } = monthlySoilService;
 
 /* ───────────────────────────── routes ─────────────────────────────── */
 
@@ -27,6 +27,9 @@ router.get('/monthly-soil/?', async (_req, res, next) => {
 router.get('/monthly-soil/full-AS/:month/?', async (req, res, next) => {
   try {
     const month = req.params.month;
+    if (!NAME_REGEX.test(month)) {
+      return res.status(400).send('Invalid month parameter');
+    }
     const monthDir = path.join(FULL_AS_DIR, month);
     const datasetNames = await monthlySoilService.listDatasets(monthDir);
     const datasets = await monthlySoilService.getDatasetDetails(FULL_AS_DIR, month, datasetNames);
@@ -45,6 +48,9 @@ router.get('/monthly-soil/full-AS/:month/?', async (req, res, next) => {
 router.get('/monthly-soil/product-AS/:month/?', async (req, res, next) => {
   try {
     const month = req.params.month;
+    if (!NAME_REGEX.test(month)) {
+      return res.status(400).send('Invalid month parameter');
+    }
     const productTypesWithDatasets = await monthlySoilService.getProductTypesWithDatasets(month);
 
     res.render('productASMonth', {

--- a/tests/bgcService.test.js
+++ b/tests/bgcService.test.js
@@ -15,18 +15,21 @@ const bgcService = require('../services/bgcService');
 describe('bgcService.getBgcInfo', () => {
   it('returns bgc info from the database', async () => {
     const rows = [{ bgc_count: 1 }];
-    client.query.mockResolvedValue({ rows });
+    pool.query.mockResolvedValue({ rows });
     cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
 
     const result = await bgcService.getBgcInfo();
 
     expect(result).toEqual(rows);
-    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1);
     expect(cacheService.getOrFetch).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('bgcService.getGcfTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('aggregates taxonomy information', async () => {
     const rows = [{ gcf_id: 1, core_taxa: 'GenusA (2)', all_taxa: 'GenusA (2), GenusB (1)' }];
     pool.query.mockResolvedValue({ rows });
@@ -34,11 +37,11 @@ describe('bgcService.getGcfTable', () => {
 
     const result = await bgcService.getGcfTable();
 
-    expect(pool.query).toHaveBeenCalledTimes(1);
-    const sql = pool.query.mock.calls[0][0];
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const sql = pool.query.mock.calls[1][0];
     expect(sql).toMatch(/core_taxa/);
     expect(sql).toMatch(/all_taxa/);
-    expect(result).toEqual(rows);
+    expect(result.data).toEqual(rows);
   });
 });
 


### PR DESCRIPTION
## Summary
- validate `month` parameter in `monthlySoilRouter`
- enforce name regex when listing months, datasets and product types
- update BGC service tests for new service behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840dd316bdc833382cc3fc21311b6f2