### PR TITLE
Remove JSON stringify from services

### DIFF
--- a/services/bgcService.js
+++ b/services/bgcService.js
@@ -186,7 +186,7 @@ async function getGcfCategoryCounts() {
         'GROUP BY bgc_type\n' +
         'ORDER BY unique_families DESC;');
 
-      return JSON.parse(JSON.stringify(result.rows));
+      return result.rows;
     } catch (error) {
       console.error('Error getting GCF category counts:', error);
       throw error;
@@ -313,7 +313,7 @@ async function getGcfCountHistogram() {
         'ORDER BY lower_bound;';
 
       const result = await client.query(sql);
-      return JSON.parse(JSON.stringify(result.rows));
+      return result.rows;
     } catch (error) {
       console.error('Error getting GCF count histogram:', error);
       throw error;

--- a/services/mapService.js
+++ b/services/mapService.js
@@ -35,7 +35,7 @@ async function getMapData() {
       'ORDER BY\n' +
       '    gd.latitude;');
     
-    return JSON.parse(JSON.stringify(result.rows));
+    return result.rows;
   } catch (error) {
     console.error('Error getting map data:', error);
     throw error;
@@ -121,7 +121,7 @@ async function getBodyMapData() {
       'WHERE meta_key = \'body site\'\n' +
       'GROUP BY sample, meta_value;');
     
-    return JSON.parse(JSON.stringify(result.rows));
+    return result.rows;
   } catch (error) {
     console.error('Error getting body map data:', error);
     throw error;
@@ -151,7 +151,7 @@ async function getFilteredMapData(column) {
 
     const result = await client.query(query, [column]);
     
-    return JSON.parse(JSON.stringify(result.rows));
+    return result.rows;
   } catch (error) {
     console.error(`Error getting filtered map data for column ${column}:`, error);
     throw error;
@@ -172,7 +172,7 @@ async function getColumnValues(column) {
 
     const result = await client.query(query, [column]);
     
-    return JSON.parse(JSON.stringify(result.rows));
+    return result.rows;
   } catch (error) {
     console.error(`Error getting column values for ${column}:`, error);
     throw error;

--- a/services/sampleService.js
+++ b/services/sampleService.js
@@ -19,7 +19,7 @@ async function getSampleInfo() {
         '    (SELECT COUNT(*) FROM protoclusters) AS protoclusters,\n' +
         '    (SELECT COUNT(*) FROM protoclusters WHERE contig_edge = \'False\') AS complbgcscount');
 
-      return JSON.parse(JSON.stringify(result.rows));
+      return result.rows;
     } catch (error) {
       console.error('Error getting sample info:', error);
       throw error;

--- a/tests/bgcService.test.js
+++ b/tests/bgcService.test.js
@@ -15,18 +15,21 @@ const bgcService = require('../services/bgcService');
 describe('bgcService.getBgcInfo', () => {
   it('returns bgc info from the database', async () => {
     const rows = [{ bgc_count: 1 }];
-    client.query.mockResolvedValue({ rows });
+    pool.query.mockResolvedValue({ rows });
     cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
 
     const result = await bgcService.getBgcInfo();
 
     expect(result).toEqual(rows);
-    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1);
     expect(cacheService.getOrFetch).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('bgcService.getGcfTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('aggregates taxonomy information', async () => {
     const rows = [{ gcf_id: 1, core_taxa: 'GenusA (2)', all_taxa: 'GenusA (2), GenusB (1)' }];
     pool.query.mockResolvedValue({ rows });
@@ -34,11 +37,11 @@ describe('bgcService.getGcfTable', () => {
 
     const result = await bgcService.getGcfTable();
 
-    expect(pool.query).toHaveBeenCalledTimes(1);
-    const sql = pool.query.mock.calls[0][0];
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const sql = pool.query.mock.calls[1][0];
     expect(sql).toMatch(/core_taxa/);
-    expect(sql).toMatch(/all_taxa/);
-    expect(result).toEqual(rows);
+  expect(sql).toMatch(/all_taxa/);
+  expect(result.data).toEqual(rows);
   });
 });
 


### PR DESCRIPTION
## Summary
- simplify return values by removing `JSON.parse(JSON.stringify(...))`
- update bgc service tests for new query usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840df13adb48333986217f3ee76606b