### PR TITLE
Use centralized error handler

### DIFF
--- a/routes/bgcRouter.js
+++ b/routes/bgcRouter.js
@@ -4,7 +4,7 @@ const bgcService = require('../services/bgcService');
 
 /* ───────────────────────────── BGC Routes ─────────────────────────────── */
 
-router.get('/bgc-info', async (req, res) => {
+router.get('/bgc-info', async (req, res, next) => {
   try {
     const gcfId = req.query.gcf ? parseInt(req.query.gcf, 10) : null;
     if (req.query.gcf && isNaN(gcfId)) {
@@ -16,11 +16,11 @@ router.get('/bgc-info', async (req, res) => {
     res.json(bgcInfo);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/pc-category-count', async (req, res) => {
+router.get('/pc-category-count', async (req, res, next) => {
   try {
     const gcfId = req.query.gcf ? parseInt(req.query.gcf, 10) : null;
     if (req.query.gcf && isNaN(gcfId)) {
@@ -32,21 +32,21 @@ router.get('/pc-category-count', async (req, res) => {
     res.json(categoryCount);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/gcf-category-count', async (req, res) => {
+router.get('/gcf-category-count', async (req, res, next) => {
   try {
     const catInfo = await bgcService.getGcfCategoryCounts();
     res.json(catInfo);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/pc-product-count', async (req, res) => {
+router.get('/pc-product-count', async (req, res, next) => {
   try {
     const gcfId = req.query.gcf ? parseInt(req.query.gcf, 10) : null;
     if (req.query.gcf && isNaN(gcfId)) {
@@ -58,11 +58,11 @@ router.get('/pc-product-count', async (req, res) => {
     res.json(productCount);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/bgc-table', async (req, res) => {
+router.get('/bgc-table', async (req, res, next) => {
   try {
     const options = {
       gcf: req.query.gcf,
@@ -81,7 +81,7 @@ router.get('/bgc-table', async (req, res) => {
     res.json(result);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ message: 'Internal server error' });
+    next(error);
   }
 });
 

--- a/routes/gcfRouter.js
+++ b/routes/gcfRouter.js
@@ -4,17 +4,17 @@ const bgcService = require('../services/bgcService');
 
 /* ───────────────────────────── GCF Routes ─────────────────────────────── */
 
-router.get('/gcf-count-hist', async (req, res) => {
+router.get('/gcf-count-hist', async (req, res, next) => {
   try {
     const bgcInfo = await bgcService.getGcfCountHistogram();
     res.json(bgcInfo);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/gcf-table-sunburst', async (req, res) => {
+router.get('/gcf-table-sunburst', async (req, res, next) => {
   try {
     const gcfId = req.query.gcf ? parseInt(req.query.gcf, 10) : null;
     if (req.query.gcf && isNaN(gcfId)) {
@@ -26,11 +26,11 @@ router.get('/gcf-table-sunburst', async (req, res) => {
     res.json(sunburstData);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/gcf-table', async (req, res) => {
+router.get('/gcf-table', async (req, res, next) => {
   try {
     // Extract pagination parameters from the request
     const options = {
@@ -47,7 +47,7 @@ router.get('/gcf-table', async (req, res) => {
     res.json(result);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ message: 'Internal server error' });
+    next(error);
   }
 });
 

--- a/routes/mapRouter.js
+++ b/routes/mapRouter.js
@@ -4,7 +4,7 @@ const mapService = require('../services/mapService');
 
 /* ───────────────────────────── Map Routes ─────────────────────────────── */
 
-router.get('/map-data-gcf', async (req, res) => {
+router.get('/map-data-gcf', async (req, res, next) => {
   try {
     const gcfId = req.query.gcf ? parseInt(req.query.gcf, 10) : null;
     if (req.query.gcf && isNaN(gcfId)) {
@@ -16,48 +16,48 @@ router.get('/map-data-gcf', async (req, res) => {
     res.json(data);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/map-data', async (req, res) => {
+router.get('/map-data', async (req, res, next) => {
   try {
     const data = await mapService.getMapData();
     res.json(data);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/body-map-data', async (req, res) => {
+router.get('/body-map-data', async (req, res, next) => {
   try {
     const data = await mapService.getBodyMapData();
     res.json(data);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/filter/:column', async (req, res) => {
+router.get('/filter/:column', async (req, res, next) => {
   try {
     const data = await mapService.getFilteredMapData(req.params.column);
     res.json(data);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/column-values/:column', async (req, res) => {
+router.get('/column-values/:column', async (req, res, next) => {
   try {
     const column = req.params.column;
     const data = await mapService.getColumnValues(column);
     res.json(data);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 

--- a/routes/monthlySoilRouter.js
+++ b/routes/monthlySoilRouter.js
@@ -20,7 +20,10 @@ router.get('/monthly-soil/?', async (_req, res, next) => {
       fullMonths, 
       productMonths 
     });
-  } catch (err) { next(err); }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
 });
 
 // 2. Full-AS month index page
@@ -38,7 +41,10 @@ router.get('/monthly-soil/full-AS/:month/?', async (req, res, next) => {
       month,
       datasets
     });
-  } catch (err) { next(err); }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
 });
 
 // 3. Product-AS month index page
@@ -54,7 +60,10 @@ router.get('/monthly-soil/product-AS/:month/?', async (req, res, next) => {
       month,
       productTypesWithDatasets
     });
-  } catch (err) { next(err); }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
 });
 
 // Note: Product-AS product type index page route removed

--- a/routes/sampleRouter.js
+++ b/routes/sampleRouter.js
@@ -4,28 +4,28 @@ const sampleService = require('../services/sampleService');
 
 /* ───────────────────────────── Sample Routes ─────────────────────────────── */
 
-router.get('/getBgcId', async (req, res) => {
+router.get('/getBgcId', async (req, res, next) => {
   try {
     const { dataset, anchor } = req.query;
     const result = await sampleService.getBgcId(dataset, anchor);
     res.json(result);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: "Database query failed" });
+    next(error);
   }
 });
 
-router.get('/sample-info', async (req, res) => {
+router.get('/sample-info', async (req, res, next) => {
   try {
     const sampleInfo = await sampleService.getSampleInfo();
     res.json(sampleInfo);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Database query error' });
+    next(error);
   }
 });
 
-router.get('/sample-data', async (req, res) => {
+router.get('/sample-data', async (req, res, next) => {
   try {
     // Extract pagination parameters from the request
     const options = {
@@ -53,17 +53,17 @@ router.get('/sample-data', async (req, res) => {
     res.json(result);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ message: 'Internal server error' });
+    next(error);
   }
 });
 
-router.get('/sample-data-2', async (req, res) => {
+router.get('/sample-data-2', async (req, res, next) => {
   try {
     const rows = await sampleService.getSampleData2();
     res.json({ data: rows });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ message: 'Internal server error' });
+    next(error);
   }
 });
 

--- a/routes/ultraDeepSoilRouter.js
+++ b/routes/ultraDeepSoilRouter.js
@@ -14,7 +14,10 @@ router.get('/ultra-deep-soil/?', async (_req, res, next) => {
     const magCount = dirs.length;
     const html = ultraDeepSoilService.generateIndexHtml(magCount);
     res.type('html').send(html);
-  } catch (err) { next(err); }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
 });
 
 // 2. MAGs index page
@@ -23,7 +26,10 @@ router.get('/ultra-deep-soil/mags/?', async (_req, res, next) => {
     const dirs = await ultraDeepSoilService.listMagDirectories();
     const html = ultraDeepSoilService.generateMagListHtml(dirs);
     res.type('html').send(html);
-  } catch (err) { next(err); }
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
 });
 
 // 3a. Serve /ultra-deep-soil/metagenome/***  (raw antiSMASH output)

--- a/routes/uploadRouter.js
+++ b/routes/uploadRouter.js
@@ -65,7 +65,7 @@ function sendEvent(message) {
 }
 
 // Upload route
-router.post('/upload', (req, res) => {
+router.post('/upload', (req, res, next) => {
   sendEvent({ status: 'Uploading' });
 
   upload(req, res, async (err) => {
@@ -80,7 +80,7 @@ router.post('/upload', (req, res) => {
       res.json(records);
     } catch (error) {
       console.error(error);
-      return res.status(500).json({ error: error.message });
+      next(error);
     }
   });
 });


### PR DESCRIPTION
## Summary
- log route errors before passing them to `next`
- rely on Express error handler for responses

## Testing
- `npm test` *(fails: bgcService tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6840df214c7c83339b8ce1befeb10dba