### PR TITLE
Refactor services to use pooled queries

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,19 +1,6 @@
 require('dotenv').config();
 
-const { Client } = require('pg');
 const { Pool } = require('pg');
-
-// Create a PostgreSQL client for single connections
-const client = new Client({
-    user: process.env.DB_USER,
-    host: process.env.DB_HOST,
-    database: process.env.DB_DATABASE,
-    password: process.env.DB_PASSWORD,
-    port: process.env.DB_PORT,
-    // ssl: process.env.NODE_ENV === 'production' ? true : {
-    //     rejectUnauthorized: false
-    // },
-});
 
 // Create a PostgreSQL pool for multiple connections
 const pool = new Pool({
@@ -27,12 +14,4 @@ const pool = new Pool({
     // },
 });
 
-client.connect((err) => {
-    if (err) {
-        console.error('Error connecting to PostgreSQL:', err.stack);
-    } else {
-        console.log(`[${new Date().toISOString()}] Connected to PostgreSQL database`);
-    }
-});
-
-module.exports = { client, pool };
+module.exports = { pool };

--- a/services/bgcService.js
+++ b/services/bgcService.js
@@ -1,4 +1,4 @@
-const { client, pool } = require('../config/database');
+const { pool } = require('../config/database');
 const cacheService = require('./cacheService');
 
 /**
@@ -161,7 +161,7 @@ async function getProductCategoryCounts(gcfId = null, samples = null) {
       `;
     }
 
-    const result = await client.query(sql, params);
+    const result = await pool.query(sql, params);
     return result.rows;
   } catch (error) {
     console.error('Error getting product category counts:', error);
@@ -180,7 +180,7 @@ async function getGcfCategoryCounts() {
   // Use the caching service to get or fetch the data
   return cacheService.getOrFetch(cacheKey, async () => {
     try {
-      const result = await client.query('SELECT bgc_type, COUNT(DISTINCT family_number) as unique_families\n' +
+      const result = await pool.query('SELECT bgc_type, COUNT(DISTINCT family_number) as unique_families\n' +
         'FROM atlas.public.bigscape_clustering\n' +
         'WHERE clustering_threshold = 0.3\n' +
         'GROUP BY bgc_type\n' +
@@ -265,7 +265,7 @@ async function getProductCounts(gcfId = null, samples = null) {
       `;
     }
 
-    const result = await client.query(sql, params);
+    const result = await pool.query(sql, params);
     return result.rows;
   } catch (error) {
     console.error('Error getting product counts:', error);
@@ -312,7 +312,7 @@ async function getGcfCountHistogram() {
         'GROUP BY bucket_range, buckets.lower_bound\n' +
         'ORDER BY lower_bound;';
 
-      const result = await client.query(sql);
+      const result = await pool.query(sql);
       return result.rows;
     } catch (error) {
       console.error('Error getting GCF count histogram:', error);
@@ -362,7 +362,7 @@ async function getGcfTableSunburst(gcfId = null, samples = null) {
 
     sql += ` GROUP BY longest_biome`;
 
-    const result = await client.query(sql, params);
+    const result = await pool.query(sql, params);
     return result.rows;
   } catch (error) {
     console.error('Error getting GCF table sunburst:', error);

--- a/services/mapService.js
+++ b/services/mapService.js
@@ -1,4 +1,4 @@
-const { client } = require('../config/database');
+const { pool } = require('../config/database');
 
 /**
  * Get map data for all samples with geographic coordinates
@@ -6,7 +6,7 @@ const { client } = require('../config/database');
  */
 async function getMapData() {
   try {
-    const result = await client.query('WITH geo_data AS (\n' +
+    const result = await pool.query('WITH geo_data AS (\n' +
       '    SELECT\n' +
       '        sample,\n' +
       '        MAX(CASE WHEN meta_key = \'geographic location (longitude)\' AND meta_value ~ \'^-?\\d+(\\.\\d+)?$\' THEN CAST(meta_value AS FLOAT) END) AS longitude,\n' +
@@ -102,7 +102,7 @@ async function getMapDataForGcf(gcfId = null, samples = null) {
           latitude
     `;
 
-    const result = await client.query(sql, params);
+    const result = await pool.query(sql, params);
     return result.rows;
   } catch (error) {
     console.error('Error getting map data for GCF:', error);
@@ -116,7 +116,7 @@ async function getMapDataForGcf(gcfId = null, samples = null) {
  */
 async function getBodyMapData() {
   try {
-    const result = await client.query('SELECT sample, meta_value\n' +
+    const result = await pool.query('SELECT sample, meta_value\n' +
       'FROM sample_metadata\n' +
       'WHERE meta_key = \'body site\'\n' +
       'GROUP BY sample, meta_value;');
@@ -149,7 +149,7 @@ async function getFilteredMapData(column) {
         AND sm2.meta_key = 'geographic location (latitude)' AND sm2.meta_value IS NOT NULL
         AND sm3.meta_key = $1 AND sm3.meta_value IS NOT NULL;`;
 
-    const result = await client.query(query, [column]);
+    const result = await pool.query(query, [column]);
     
     return result.rows;
   } catch (error) {
@@ -170,7 +170,7 @@ async function getColumnValues(column) {
       WHERE meta_key = $1
       ORDER BY meta_value ASC`;
 
-    const result = await client.query(query, [column]);
+    const result = await pool.query(query, [column]);
     
     return result.rows;
   } catch (error) {

--- a/services/sampleService.js
+++ b/services/sampleService.js
@@ -1,4 +1,4 @@
-const { client, pool } = require('../config/database');
+const { pool } = require('../config/database');
 const cacheService = require('./cacheService');
 
 /**
@@ -12,7 +12,7 @@ async function getSampleInfo() {
   // Use the caching service to get or fetch the data
   return cacheService.getOrFetch(cacheKey, async () => {
     try {
-      const result = await client.query('SELECT\n' +
+      const result = await pool.query('SELECT\n' +
         '    (SELECT COUNT(*) FROM mgnify_asms) AS "sample_count",\n' +
         '    (SELECT COUNT(*) FROM antismash_runs WHERE status = \'success\') AS "success",\n' +
         '    (SELECT COUNT(*) FROM antismash_runs WHERE status = \'runningAS\') AS "running",\n' +
@@ -281,7 +281,7 @@ async function getBgcId(dataset, anchor) {
   return cacheService.getOrFetch(cacheKey, async () => {
     try {
       const query = 'SELECT region_id FROM regions WHERE assembly = $1 AND anchor = $2';
-      const result = await client.query(query, [dataset, anchor]);
+      const result = await pool.query(query, [dataset, anchor]);
 
       if (result.rows.length > 0) {
         return { bgcId: result.rows[0].region_id };

--- a/tests/bgcService.test.js
+++ b/tests/bgcService.test.js
@@ -1,8 +1,7 @@
 const cacheService = require('../services/cacheService');
-const { client, pool } = require('../config/database');
+const { pool } = require('../config/database');
 
 jest.mock('../config/database', () => ({
-  client: { query: jest.fn() },
   pool: { query: jest.fn() }
 }));
 

--- a/tests/mapService.test.js
+++ b/tests/mapService.test.js
@@ -1,18 +1,18 @@
 jest.mock('../config/database', () => ({
-  client: { query: jest.fn() }
+  pool: { query: jest.fn() }
 }));
 
 const mapService = require('../services/mapService');
-const { client } = require('../config/database');
+const { pool } = require('../config/database');
 
 describe('mapService.getMapData', () => {
   it('returns map data from the database', async () => {
     const rows = [{ sample: 's1', longitude: 1.23, latitude: 4.56, assembly: 'a1' }];
-    client.query.mockResolvedValue({ rows });
+    pool.query.mockResolvedValue({ rows });
 
     const result = await mapService.getMapData();
 
-    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1);
     expect(result).toEqual(rows);
   });
 });

--- a/tests/sampleService.test.js
+++ b/tests/sampleService.test.js
@@ -1,6 +1,5 @@
 jest.mock('../config/database', () => ({
-  client: { query: jest.fn() },
-  pool: {}
+  pool: { query: jest.fn() }
 }));
 
 jest.mock('../services/cacheService', () => ({
@@ -8,19 +7,19 @@ jest.mock('../services/cacheService', () => ({
 }));
 
 const sampleService = require('../services/sampleService');
-const { client } = require('../config/database');
+const { pool } = require('../config/database');
 const cacheService = require('../services/cacheService');
 
 describe('sampleService.getSampleInfo', () => {
   it('returns sample info from the database', async () => {
     const rows = [{ sample_count: 1, success: 2, running: 0, protoclusters: 4, complbgcscount: 3 }];
-    client.query.mockResolvedValue({ rows });
+    pool.query.mockResolvedValue({ rows });
     cacheService.getOrFetch.mockImplementation((key, fetch) => fetch());
 
     const result = await sampleService.getSampleInfo();
 
     expect(result).toEqual(rows);
-    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(pool.query).toHaveBeenCalledTimes(1);
     expect(cacheService.getOrFetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- simplify database module to only export a `Pool`
- refactor services to use `pool.query`
- update unit tests to mock the pool interface

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e17e1fb48333a749d10d1a979021