### PR TITLE
Add startup path validation

### DIFF
--- a/bin/test.js
+++ b/bin/test.js
@@ -2,9 +2,18 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('bgc-atlas:test');
+const { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathValidator');
 const app = require('../app');
 
 const certDir = process.env.SSL_CERT_PATH || '/etc/letsencrypt/live/bgc-atlas.cs.uni-tuebingen.de';
+try {
+  validateSSLCertPath(certDir);
+  validateRequiredPaths();
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+
 const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
 const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
 

--- a/bin/www
+++ b/bin/www
@@ -11,9 +11,18 @@ var http = require('http');
 var https = require('https');
 var fs = require('fs');
 var path = require('path');
+var { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathValidator');
 
 
 const certDir = process.env.SSL_CERT_PATH || '/etc/letsencrypt/live/bgc-atlas.cs.uni-tuebingen.de';
+try {
+  validateSSLCertPath(certDir);
+  validateRequiredPaths();
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+
 const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
 const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
 const ca = fs.readFileSync(path.join(certDir, 'chain.pem'), 'utf8');

--- a/tests/pathValidator.test.js
+++ b/tests/pathValidator.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathValidator');
+
+describe('validateSSLCertPath', () => {
+  it('throws when directory is missing', () => {
+    expect(() => validateSSLCertPath('/non/existent')).toThrow('SSL certificate directory not found');
+  });
+
+  it('passes when directory and files exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cert-'));
+    fs.writeFileSync(path.join(dir, 'privkey.pem'), 'key');
+    fs.writeFileSync(path.join(dir, 'fullchain.pem'), 'cert');
+
+    expect(() => validateSSLCertPath(dir)).not.toThrow();
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('validateRequiredPaths', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('throws when env vars are missing', () => {
+    delete process.env.SEARCH_SCRIPT_PATH;
+    delete process.env.REPORTS_DIR;
+    expect(() => validateRequiredPaths()).toThrow('SEARCH_SCRIPT_PATH');
+  });
+
+  it('throws when paths do not exist', () => {
+    process.env.SEARCH_SCRIPT_PATH = '/no/script';
+    process.env.REPORTS_DIR = '/no/reports';
+    expect(() => validateRequiredPaths()).toThrow('does not exist');
+  });
+
+  it('passes with valid paths', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'validator-'));
+    const script = path.join(tmp, 'script.sh');
+    fs.writeFileSync(script, '#!/bin/bash');
+    const reports = fs.mkdtempSync(path.join(os.tmpdir(), 'reports-'));
+
+    process.env.SEARCH_SCRIPT_PATH = script;
+    process.env.REPORTS_DIR = reports;
+
+    expect(() => validateRequiredPaths()).not.toThrow();
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(reports, { recursive: true, force: true });
+  });
+});

--- a/utils/pathValidator.js
+++ b/utils/pathValidator.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('bgc-atlas:pathValidator');
+
+function validateSSLCertPath(certDir) {
+  if (!fs.existsSync(certDir)) {
+    throw new Error(`SSL certificate directory not found: ${certDir}`);
+  }
+  const required = ['privkey.pem', 'fullchain.pem'];
+  required.forEach(f => {
+    const p = path.join(certDir, f);
+    if (!fs.existsSync(p)) {
+      throw new Error(`Missing SSL certificate file: ${p}`);
+    }
+  });
+  debug(`Using SSL certificates from ${certDir}`);
+}
+
+function validateRequiredPaths() {
+  const requiredEnv = {
+    SEARCH_SCRIPT_PATH: process.env.SEARCH_SCRIPT_PATH,
+    REPORTS_DIR: process.env.REPORTS_DIR,
+  };
+
+  for (const [name, value] of Object.entries(requiredEnv)) {
+    if (!value) {
+      throw new Error(`Required environment variable ${name} is not set`);
+    }
+    if (!fs.existsSync(value)) {
+      throw new Error(`Path for ${name} does not exist: ${value}`);
+    }
+    debug(`${name} => ${value}`);
+  }
+}
+
+module.exports = { validateSSLCertPath, validateRequiredPaths };


### PR DESCRIPTION
## Summary
- validate SSL certs and required directories when starting app
- expose reusable path validation helpers
- test path validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e52508288333ac970c813425c24c