### PR TITLE
Introduce reusable Pug components

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ BGC Atlas is built with the following main dependencies:
 
 For a complete list of dependencies, see the `package.json` file.
 
+## Frontend Components
+
+The user interface is built with Pug templates. Reusable pieces of markup live in the `views/components` directory as mixins. Core elements such as the navigation bar and footer are defined once and included across all pages. Additional components, like a generic card, can be composed to simplify future UI work.
+
 ## Data
 
 The current version of BGC Atlas includes:

--- a/views/components/card.pug
+++ b/views/components/card.pug
@@ -1,0 +1,7 @@
+mixin card(title)
+  .card.mb-3
+    if title
+      .card-header #{title}
+    .card-body
+      block
+

--- a/views/components/footer.pug
+++ b/views/components/footer.pug
@@ -1,0 +1,7 @@
+mixin footer()
+  footer.text-center.bg-dark.text-white
+    p University of Tübingen - 2025 -
+      a(href='/imprint') Imprint
+      |  -
+      a(href='/privacy') Privacy Policy
+

--- a/views/components/navbar.pug
+++ b/views/components/navbar.pug
@@ -1,0 +1,23 @@
+mixin navbar(activePage)
+  nav.navbar.navbar-expand-sm.navbar-dark.bg-dark(style="width:100%;" aria-label="Main Navigation")
+    .container-fluid
+      a.navbar-brand(href='/') BGC Atlas
+      button.navbar-toggler(type='button' data-bs-toggle='collapse' data-bs-target='#mynavbar' aria-controls='mynavbar' aria-label='Toggle navigation' aria-expanded='false')
+        span.navbar-toggler-icon
+      #mynavbar.collapse.navbar-collapse
+        ul.navbar-nav.me-auto
+          li.nav-item
+            a.nav-link(href='/' class=activePage === 'home' ? 'active' : '') Home
+          li.nav-item
+            a.nav-link(href='/samples' class=activePage === 'samples' ? 'active' : '') Samples
+          li.nav-item
+            a.nav-link(href='/bgcs' class=activePage === 'bgcs' ? 'active' : '') BGCs
+          li.nav-item
+            a.nav-link(href='/gcfs' class=activePage === 'gcfs' ? 'active' : '') GCFs
+          li.nav-item
+            a.nav-link(href='/search' class=activePage === 'search' ? 'active' : '') Search
+          li.nav-item
+            a.nav-link(href='/downloads' class=activePage === 'downloads' ? 'active' : '') Downloads
+          li.nav-item
+            a.nav-link(href='/about' class=activePage === 'about' ? 'active' : '') About
+

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,4 +1,5 @@
 extends layout.pug
+include components/card
 
 block head
   link(rel="stylesheet", href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css")
@@ -15,22 +16,22 @@ block content
   .container.d-flex.flex-column.h-100
     .row.flex-grow-1
       #sample-info.col-md-4
-        h3 Sample Information
-        p
-          strong Total Samples: 
-          span#samples-count Loading...
-        p
-          strong Analyzed: 
-          span#analyzed-count Loading...
-        p
-          strong Running: 
-          span#running-count Loading...
-        p
-          strong BGCs: 
-          span#bgcs-count Loading...
-        p
-          strong Complete BGCs: 
-          span#compl-bgcs Loading...
+        +card('Sample Information')
+          p
+            strong Total Samples:
+            span#samples-count Loading...
+          p
+            strong Analyzed:
+            span#analyzed-count Loading...
+          p
+            strong Running:
+            span#running-count Loading...
+          p
+            strong BGCs:
+            span#bgcs-count Loading...
+          p
+            strong Complete BGCs:
+            span#compl-bgcs Loading...
       #map.col-md-8
 
 block scripts

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,3 +1,6 @@
+include components/navbar
+include components/footer
+
 doctype html
 html(lang="en")
     block head
@@ -31,34 +34,10 @@ html(lang="en")
         link(rel="preconnect", href="https://cdnjs.cloudflare.com")
     body
         main.w-100.d-flex.flex-column
-            nav.navbar.navbar-expand-sm.navbar-dark.bg-dark(style="width:100%;" aria-label="Main Navigation")
-                .container-fluid
-                    a.navbar-brand(href='/') BGC Atlas
-                    button.navbar-toggler(type='button' data-bs-toggle='collapse' data-bs-target='#mynavbar' aria-controls='mynavbar' aria-label='Toggle navigation' aria-expanded='false')
-                        span.navbar-toggler-icon
-                    #mynavbar.collapse.navbar-collapse
-                        ul.navbar-nav.me-auto
-                            li.nav-item
-                                a.nav-link(href='/', class=activePage === 'home' ? 'active' : '') Home
-                            li.nav-item
-                                a.nav-link(href='/samples', class=activePage === 'samples' ? 'active' : '') Samples
-                            li.nav-item
-                                a.nav-link(href='/bgcs', class=activePage === 'bgcs' ? 'active' : '') BGCs
-                            li.nav-item
-                                a.nav-link(href='/gcfs', class=activePage === 'gcfs' ? 'active' : '') GCFs
-                            li.nav-item
-                                a.nav-link(href="/search", class=activePage === 'search' ? 'active' : '') Search
-                            li.nav-item
-                                a.nav-link(href="/downloads", class=activePage === 'downloads' ? 'active' : '') Downloads
-                            li.nav-item
-                                a.nav-link(href="/about", class=activePage === 'about' ? 'active' : '') About
-                        //form.d-flex
-                        //    input.form-control.me-2(type='text' placeholder='Search')
-                        //    button.btn.btn-primary(type='button') Search
+            +navbar(activePage)
             div.content-container
                 block content
-            footer.text-center.bg-dark.text-white
-                p University of Tübingen - 2025 - <a href="/imprint">Imprint</a> - <a href="/privacy">Privacy Policy</a>
+            +footer()
 
         block scripts
 


### PR DESCRIPTION
## Summary
- create `views/components` folder with navbar, footer and card mixins
- refactor layout to use navbar and footer components
- use new card component on the home page
- document component-based approach in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f5af88b4833390f04894f7cca22b