### PR TITLE
Sanitize error messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const path = require('path');
 const cookieParser = require('cookie-parser');
 const morgan = require('morgan');
 const logger = require('./utils/logger');
+const { sanitizeMessage } = require('./utils/sanitize');
 const geoip = require('geoip-lite');
 const compression = require('compression');
 const etagMiddleware = require('./services/etagMiddleware');
@@ -207,9 +208,14 @@ app.use(function(req, res, next) {
 
 // error handler
 app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
+  // set locals, only providing detailed error in development
+  if (req.app.get('env') === 'development') {
+    res.locals.message = sanitizeMessage(err.message);
+    res.locals.error = err;
+  } else {
+    res.locals.message = 'An unexpected error occurred';
+    res.locals.error = {};
+  }
 
   logger.error('Unhandled error', err);
 

--- a/routes/bgcRouter.js
+++ b/routes/bgcRouter.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const bgcService = require('../services/bgcService');
 const { defaultRateLimiter } = require('../services/rateLimitMiddleware');
 const logger = require('../utils/logger');
+const { sanitizeMessage } = require('../utils/sanitize');
 
 /* ───────────────────────────── BGC Routes ─────────────────────────────── */
 
@@ -27,7 +28,7 @@ router.get('/bgc-info', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);
@@ -47,7 +48,7 @@ router.get('/pc-category-count', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);
@@ -77,7 +78,7 @@ router.get('/pc-product-count', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);
@@ -97,7 +98,7 @@ router.get('/pc-taxonomic-count', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);
@@ -130,7 +131,7 @@ router.get('/bgc-table', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);

--- a/routes/sampleRouter.js
+++ b/routes/sampleRouter.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const sampleService = require('../services/sampleService');
 const { defaultRateLimiter } = require('../services/rateLimitMiddleware');
 const logger = require('../utils/logger');
+const { sanitizeMessage } = require('../utils/sanitize');
 
 /* ───────────────────────────── Sample Routes ─────────────────────────────── */
 
@@ -24,7 +25,7 @@ router.get('/getBgcId', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);
@@ -76,7 +77,7 @@ router.get('/sample-data', async (req, res, next) => {
 
     // Handle validation errors with appropriate status code
     if (error.message && error.message.includes('Invalid')) {
-      return res.status(400).json({ error: error.message });
+      return res.status(400).json({ error: sanitizeMessage(error.message) });
     }
 
     next(error);

--- a/routes/uploadRouter.js
+++ b/routes/uploadRouter.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { v4: uuidv4 } = require('uuid');
 const searchService = require('../services/searchService');
 const logger = require('../utils/logger');
+const { sanitizeMessage } = require('../utils/sanitize');
 const csrf = require('csurf');
 
 /* ───────────────────────────── Upload Routes ─────────────────────────────── */
@@ -109,9 +110,10 @@ router.post('/upload', (req, res, next) => {
   // First process the file upload with multer
   upload(req, res, async (err) => {
     if (err) {
-      sendEvent({ status: 'Error', message: err.message });
+      const sanitized = sanitizeMessage(err.message);
+      sendEvent({ status: 'Error', message: sanitized });
       const status = err.message.includes('.gbk') || err.message.includes('.genbank') ? 400 : 500;
-      return res.status(status).json({ error: err.message });
+      return res.status(status).json({ error: sanitized });
     }
 
     // Then validate the CSRF token

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,7 @@
+function sanitizeMessage(message) {
+  if (!message) return '';
+  const pathRegex = /([A-Za-z]:)?[\\/][^\s']+/g;
+  return message.replace(pathRegex, '[path]');
+}
+
+module.exports = { sanitizeMessage };


### PR DESCRIPTION
## Summary
- avoid leaking filesystem paths or other info in user-facing messages
- sanitize upload and scheduler errors
- show generic error page message when not in development

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e15758e483338d114961964e3078