### PR TITLE
Log job submitter IP

### DIFF
--- a/services/searchService.js
+++ b/services/searchService.js
@@ -56,9 +56,15 @@ async function processUploadedFiles(req, sendEvent) {
     const uploadDir = req.uploadDir;
     const fileNames = files.map(file => file.name);
 
-    // Create a job
-    const userId = req.user ? req.user.id : null;
-    const jobId = await jobService.createJob(userId, uploadDir, files.length, fileNames);
+    // Determine IP address for logging
+    const ipAddress =
+      (req.headers && req.headers['x-forwarded-for']) ||
+      req.ip ||
+      (req.connection && req.connection.remoteAddress) ||
+      '';
+
+    // Create a job using the IP address as the user identifier
+    const jobId = await jobService.createJob(ipAddress, uploadDir, files.length, fileNames);
 
     // Create an event emitter for this job
     const jobEmitter = new EventEmitter();

--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const fs = require('fs-extra');
 const { spawn } = require('child_process');
+const jobService = require('../services/jobService');
 
 jest.mock('fs-extra', () => ({
   ensureDirSync: jest.fn(),
@@ -59,8 +60,11 @@ describe('processUploadedFiles', () => {
 
     const req = {
       files: [{ originalname: 'f.txt', filename: 'f.txt', path: '/ceph/ibmi/tgm/bgc-atlas/search/uploads/f.txt' }],
-      uploadDir: '/tmp/up'
+      uploadDir: '/tmp/up',
+      ip: '1.2.3.4',
+      headers: {}
     };
+    const createJobSpy = jest.spyOn(jobService, 'createJob');
     const sendEvent = jest.fn();
     const promise = processUploadedFiles(req, sendEvent);
 
@@ -69,6 +73,7 @@ describe('processUploadedFiles', () => {
 
     const result = await promise;
 
+    expect(createJobSpy).toHaveBeenCalledWith('1.2.3.4', '/tmp/up', 1, ['f.txt']);
     expect(spawn).toHaveBeenCalledWith('/tmp/search/script.sh', ['/tmp/up'], { shell: false });
     expect(sendEvent).toHaveBeenCalledWith({ status: 'Running' });
     expect(sendEvent).toHaveBeenLastCalledWith({ status: 'Complete', records: result });


### PR DESCRIPTION
## Summary
- track job submissions using the request IP address
- verify IP logging logic via unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e185f13083338721eaac0828e50a