### PR TITLE
Add ENABLE_SSL toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ DB_PORT=5432
 APP_URL=http://localhost
 PORT=443
 
+# Set to 'false' to disable HTTPS and start the server over HTTP
+ENABLE_SSL=true
+
 
 
 # Path to SSL certificates directory

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ To set up a local instance of BGC Atlas, follow these steps:
    MONTHLY_SOIL_BASE_DIR=/path/to/monthly-soil  # Optional: Path to monthly soil data directory
    ULTRA_DEEP_SOIL_DIR=/path/to/ultra-deep-soil  # Optional: Path to ultra-deep soil data directory
    SEARCH_UPLOADS_DIR=/path/to/search/uploads  # Optional: Path to store uploaded files for search
-   SEARCH_SCRIPT_PATH=/path/to/search/script.py  # Required: Path to the search script
-   REPORTS_DIR=/path/to/reports  # Required: Path to store search reports
-   SSL_CERT_PATH=/path/to/ssl/certs  # Optional: Path to SSL certificates
+    SEARCH_SCRIPT_PATH=/path/to/search/script.py  # Required: Path to the search script
+    REPORTS_DIR=/path/to/reports  # Required: Path to store search reports
+    ENABLE_SSL=true  # Set to false to disable HTTPS
+    SSL_CERT_PATH=/path/to/ssl/certs  # Optional: Path to SSL certificates
    ```
 
 4. Set up the database:

--- a/bin/test.js
+++ b/bin/test.js
@@ -6,26 +6,37 @@ const { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathVal
 const app = require('../app');
 const logger = require('../utils/logger');
 
+const enableSSL = process.env.ENABLE_SSL !== 'false';
 const certDir = process.env.SSL_CERT_PATH || '/etc/letsencrypt/live/bgc-atlas.cs.uni-tuebingen.de';
 try {
-  validateSSLCertPath(certDir);
   validateRequiredPaths();
 } catch (err) {
   logger.error(err.message);
   process.exit(1);
 }
 
-const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
-const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
-
-const credentials = {
-    key: privateKey,
-    cert: certificate
-};
+let credentials;
+if (enableSSL) {
+  try {
+    validateSSLCertPath(certDir);
+    const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
+    const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
+    credentials = { key: privateKey, cert: certificate };
+  } catch (err) {
+    logger.error(`SSL setup failed: ${err.message}. Falling back to HTTP.`);
+  }
+}
 
 const port = 3000; // Use a different port than 443 for local testing
 
-const server = https.createServer(credentials, app);
+let server;
+if (credentials) {
+  server = https.createServer(credentials, app);
+  logger.info('Starting HTTPS server for tests');
+} else {
+  server = require('http').createServer(app);
+  logger.info('Starting HTTP server for tests');
+}
 
 server.listen(port, () => {
     debug(`Server running locally on port ${port}`);

--- a/bin/www
+++ b/bin/www
@@ -15,31 +15,34 @@ var { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathValid
 var logger = require('../utils/logger');
 
 
+const enableSSL = process.env.ENABLE_SSL !== 'false';
 const certDir = process.env.SSL_CERT_PATH || '/etc/letsencrypt/live/bgc-atlas.cs.uni-tuebingen.de';
+
 try {
-  validateSSLCertPath(certDir);
   validateRequiredPaths();
 } catch (err) {
   logger.error(err.message);
   process.exit(1);
 }
 
-const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
-const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
-const ca = fs.readFileSync(path.join(certDir, 'chain.pem'), 'utf8');
-
-
-const credentials = {
-  key: privateKey,
-  cert: certificate,
-  ca: ca
-};
+let credentials;
+if (enableSSL) {
+  try {
+    validateSSLCertPath(certDir);
+    const privateKey = fs.readFileSync(path.join(certDir, 'privkey.pem'), 'utf8');
+    const certificate = fs.readFileSync(path.join(certDir, 'fullchain.pem'), 'utf8');
+    const ca = fs.readFileSync(path.join(certDir, 'chain.pem'), 'utf8');
+    credentials = { key: privateKey, cert: certificate, ca: ca };
+  } catch (err) {
+    logger.error(`SSL setup failed: ${err.message}. Falling back to HTTP.`);
+  }
+}
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '443');
+var port = normalizePort(process.env.PORT || (credentials ? '443' : '80'));
 app.set('port', port);
 
 
@@ -47,9 +50,14 @@ app.set('port', port);
  * Create HTTP server.
  */
 //
-// var server = http.createServer(app);
-
-const server = https.createServer(credentials, app);
+let server;
+if (credentials) {
+  server = https.createServer(credentials, app);
+  logger.info('Starting HTTPS server');
+} else {
+  server = http.createServer(app);
+  logger.info('Starting HTTP server');
+}
 
 
 /**
@@ -104,7 +112,7 @@ function onError(error) {
       process.exit(1);
       break;
     default:
-      logger.error('Error occurred while starting HTTPS server:', error);
+      logger.error('Error occurred while starting server:', error);
       process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- allow disabling SSL via `ENABLE_SSL` env var
- fall back to HTTP server when SSL is disabled or certs invalid
- document `ENABLE_SSL` usage
- update example environment file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e319662c83338f6678f3b30da616