### PR TITLE
Add chain.pem requirement to SSL validator

### DIFF
--- a/tests/pathValidator.test.js
+++ b/tests/pathValidator.test.js
@@ -12,8 +12,20 @@ describe('validateSSLCertPath', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cert-'));
     fs.writeFileSync(path.join(dir, 'privkey.pem'), 'key');
     fs.writeFileSync(path.join(dir, 'fullchain.pem'), 'cert');
+    fs.writeFileSync(path.join(dir, 'chain.pem'), 'intermediate');
 
     expect(() => validateSSLCertPath(dir)).not.toThrow();
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throws when a required file is missing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cert-'));
+    fs.writeFileSync(path.join(dir, 'privkey.pem'), 'key');
+    fs.writeFileSync(path.join(dir, 'fullchain.pem'), 'cert');
+    // chain.pem is intentionally missing
+
+    expect(() => validateSSLCertPath(dir)).toThrow('Missing SSL certificate file');
 
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/utils/pathValidator.js
+++ b/utils/pathValidator.js
@@ -6,7 +6,7 @@ function validateSSLCertPath(certDir) {
   if (!fs.existsSync(certDir)) {
     throw new Error(`SSL certificate directory not found: ${certDir}`);
   }
-  const required = ['privkey.pem', 'fullchain.pem'];
+  const required = ['privkey.pem', 'fullchain.pem', 'chain.pem'];
   required.forEach(f => {
     const p = path.join(certDir, f);
     if (!fs.existsSync(p)) {


### PR DESCRIPTION
## Summary
- validate chain.pem with privkey and fullchain in `validateSSLCertPath`
- update SSL cert validation tests to include chain.pem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e32376b48333b9b1413a87e3902f