### PR TITLE
Fix job completion status handling

### DIFF
--- a/public/javascripts/job_status.js
+++ b/public/javascripts/job_status.js
@@ -179,8 +179,8 @@ function checkJobStatus(jobId) {
                 }
             }
 
-            // Check for both lowercase 'completed' and capitalized 'Complete'
-            if (job.status === 'completed' || job.status === 'Complete') {
+            // Load results when job is completed
+            if (job.status === 'completed') {
                 console.log(`Job ${jobId} is completed, loading results`);
                 loadJobResults(jobId);
             } else if (job.status === 'queued' || job.status === 'running') {
@@ -706,8 +706,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             }
 
-            // If job is complete and has results, display them
-            if (data.status === 'Complete' && data.records) {
+            // If job is completed and has results, display them
+            if (data.status === 'completed' && data.records) {
                 console.log(`Job ${jobId} is complete with ${data.records.length} results, displaying them`);
 
                 // Check if the hide putative toggle is checked

--- a/routes/jobRouter.js
+++ b/routes/jobRouter.js
@@ -45,8 +45,8 @@ router.get('/:jobId/results', async (req, res, next) => {
       return res.status(404).json({ error: 'Job not found' });
     }
 
-    // Check for both lowercase 'completed' and capitalized 'Complete'
-    if (job.status !== 'completed' && job.status !== 'Complete') {
+    // Ensure job is completed before returning results
+    if (job.status !== 'completed') {
       return res.status(400).json({ 
         error: 'Job not completed', 
         status: job.status 

--- a/services/schedulerService.js
+++ b/services/schedulerService.js
@@ -30,7 +30,7 @@ function processJob(jobId, emitter) {
           emitter?.emit('status', { status: message.status, jobId: message.jobId });
           break;
         case 'complete':
-          emitter?.emit('complete', { status: 'Complete', records: message.records, jobId: message.jobId });
+          emitter?.emit('complete', { status: 'completed', records: message.records, jobId: message.jobId });
           break;
         case 'error':
           emitter?.emit('error', { status: 'Error', message: message.message || message.error, output: message.output, jobId: message.jobId });
@@ -94,7 +94,7 @@ async function runJobInline(jobId, emitter) {
   });
   await jobService.storeResults(jobId, records);
   await jobService.updateJobStatus(jobId, 'completed');
-  emitter?.emit('complete', { status: 'Complete', records, jobId });
+  emitter?.emit('complete', { status: 'completed', records, jobId });
   jobEmitters.delete(jobId);
 }
 

--- a/services/searchService.js
+++ b/services/searchService.js
@@ -81,7 +81,7 @@ async function processUploadedFiles(req, sendEvent) {
       jobEmitter.emit('status', { status: 'Running' });
       spawn(process.env.SEARCH_SCRIPT_PATH, [uploadDir], { shell: false });
       const records = [{ bgc_name: 'bgc', gcf_id: '123', membership_value: '0.9' }];
-      jobEmitter.emit('complete', { status: 'Complete', records });
+      jobEmitter.emit('complete', { status: 'completed', records });
       return records;
     } else {
       // Schedule the job

--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -71,7 +71,7 @@ describe('processUploadedFiles', () => {
 
     expect(spawn).toHaveBeenCalledWith('/tmp/search/script.sh', ['/tmp/up'], { shell: false });
     expect(sendEvent).toHaveBeenCalledWith({ status: 'Running' });
-    expect(sendEvent).toHaveBeenLastCalledWith({ status: 'Complete', records: result });
+    expect(sendEvent).toHaveBeenLastCalledWith({ status: 'completed', records: result });
     expect(result).toEqual([{ bgc_name: 'bgc', gcf_id: '123', membership_value: '0.9' }]);
   });
 });


### PR DESCRIPTION
## Summary
- unify completed status strings in services and router
- simplify job result status checks
- update client job status script
- fix tests expecting new status value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e32d3e74833395e13849c3ff1d0c