### PR TITLE
Add Redis configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ DB_DATABASE=bgc_atlas
 DB_PASSWORD=change_me
 DB_PORT=5432
 
+# Redis configuration
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+
 # Application URL and server port
 APP_URL=http://localhost
 PORT=443

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ requires **Node.js 18** or later:
    PORT=3000
    APP_URL=http://localhost:3000
    DATABASE_URL=postgres://username:password@localhost:5432/bgcatlas
+   REDIS_HOST=127.0.0.1  # Redis host for Bull queue
+   REDIS_PORT=6379       # Redis port for Bull queue
    MONTHLY_SOIL_BASE_DIR=/path/to/monthly-soil  # Optional: Path to monthly soil data directory
    ULTRA_DEEP_SOIL_DIR=/path/to/ultra-deep-soil  # Optional: Path to ultra-deep soil data directory
    SEARCH_UPLOADS_DIR=/path/to/search/uploads  # Optional: Path to store uploaded files for search

--- a/services/schedulerService.js
+++ b/services/schedulerService.js
@@ -8,9 +8,12 @@ const { sanitizeMessage } = require('../utils/sanitize');
 // Map of jobId -> event emitter
 const jobEmitters = new Map();
 
-// Create Bull queue using local Redis
+// Create Bull queue using Redis connection details from env vars
 const queue = process.env.NODE_ENV === 'test' ? null : new Bull('searchQueue', {
-  redis: { host: '127.0.0.1', port: 6379 }
+  redis: {
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: process.env.REDIS_PORT ? parseInt(process.env.REDIS_PORT, 10) : 6379
+  }
 });
 
 let processorInitialized = false;


### PR DESCRIPTION
## Summary
- add `REDIS_HOST` and `REDIS_PORT` defaults to `.env.example`
- document new vars in README
- configure scheduler service to use the new Redis settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841eb90a7dc8333b542a7cc13941e3b