### PR TITLE
Add job and scheduler unit tests

### DIFF
--- a/tests/jobService.test.js
+++ b/tests/jobService.test.js
@@ -1,0 +1,51 @@
+jest.mock('../config/database', () => ({
+  pool: { query: jest.fn() }
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-job-id')
+}));
+
+const { pool } = require('../config/database');
+const jobService = require('../services/jobService');
+
+const originalEnv = process.env.NODE_ENV;
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'development';
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalEnv;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('jobService.createJob', () => {
+  it('inserts a new job and returns its id', async () => {
+    pool.query.mockResolvedValue({});
+
+    const id = await jobService.createJob('user1', '/tmp/up', 2, ['a', 'b']);
+
+    expect(id).toBe('mock-job-id');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO search_jobs'),
+      ['mock-job-id', 'user1', 'queued', '/tmp/up', 2, ['a', 'b']]
+    );
+  });
+});
+
+describe('jobService.updateJobStatus', () => {
+  it('updates status in the database', async () => {
+    pool.query.mockResolvedValue({});
+
+    await jobService.updateJobStatus('job1', 'running');
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE search_jobs'),
+      ['running', 'job1']
+    );
+  });
+});

--- a/tests/schedulerService.test.js
+++ b/tests/schedulerService.test.js
@@ -1,0 +1,75 @@
+const EventEmitter = require('events');
+
+const mockQueue = {
+  add: jest.fn(() => Promise.resolve()),
+  getWaiting: jest.fn(() => Promise.resolve([])),
+  getActive: jest.fn(() => Promise.resolve([])),
+  getJob: jest.fn(() => Promise.resolve(null)),
+  close: jest.fn(() => Promise.resolve()),
+  process: jest.fn()
+};
+
+jest.mock('bull', () => jest.fn().mockImplementation(() => mockQueue));
+
+const originalEnv = process.env.NODE_ENV;
+let schedulerService;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.NODE_ENV = 'development';
+  schedulerService = require('../services/schedulerService');
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalEnv;
+});
+
+describe('schedulerService.scheduleJob', () => {
+  it('adds job to queue and emits queued status', async () => {
+    const emitter = new EventEmitter();
+    jest.spyOn(emitter, 'emit');
+    mockQueue.getWaiting.mockResolvedValueOnce([{ data: { jobId: 'job1' } }]);
+
+    await schedulerService.scheduleJob('job1', emitter);
+
+    expect(mockQueue.add).toHaveBeenCalledWith({ jobId: 'job1' }, { jobId: 'job1' });
+    expect(emitter.emit).toHaveBeenCalledWith('status', {
+      status: 'Queued',
+      jobId: 'job1',
+      queuePosition: 1,
+      totalJobs: 1
+    });
+  });
+});
+
+describe('schedulerService.getQueueInfo', () => {
+  it('returns queue information for a job', async () => {
+    mockQueue.getWaiting.mockResolvedValueOnce([
+      { data: { jobId: 'other' } },
+      { data: { jobId: 'job2' } }
+    ]);
+    mockQueue.getActive.mockResolvedValueOnce([]);
+
+    const info = await schedulerService.getQueueInfo('job2');
+
+    expect(info).toEqual({
+      queuePosition: 2,
+      totalJobs: 2,
+      isQueued: true,
+      isRunning: false
+    });
+  });
+});
+
+describe('schedulerService.getQueuedJobs', () => {
+  it('lists queued job IDs', async () => {
+    mockQueue.getWaiting.mockResolvedValueOnce([
+      { data: { jobId: 'a' } },
+      { data: { jobId: 'b' } }
+    ]);
+
+    const jobs = await schedulerService.getQueuedJobs();
+
+    expect(jobs).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for job service create/update operations
- add unit tests for queue behaviour in scheduler service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841efc952688333a512bb5a1292ed97