### PR TITLE
Add rate limit to SSE events

### DIFF
--- a/routes/uploadRouter.js
+++ b/routes/uploadRouter.js
@@ -6,6 +6,7 @@ const { v4: uuidv4 } = require('uuid');
 const searchService = require('../services/searchService');
 const logger = require('../utils/logger');
 const { sanitizeMessage } = require('../utils/sanitize');
+const { defaultRateLimiter } = require('../services/rateLimitMiddleware');
 const csrf = require('csurf');
 
 /* ───────────────────────────── Upload Routes ─────────────────────────────── */
@@ -67,7 +68,7 @@ setInterval(() => {
 }, 30000);
 
 // SSE route
-router.get('/events', (req, res) => {
+router.get('/events', defaultRateLimiter, (req, res) => {
   console.log('New SSE client connected');
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');

--- a/tests/uploadRouter.events.test.js
+++ b/tests/uploadRouter.events.test.js
@@ -1,0 +1,18 @@
+const { defaultRateLimiter } = require('../services/rateLimitMiddleware');
+
+// Use fake timers to prevent the interval in uploadRouter from running
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+test('events endpoint is protected by defaultRateLimiter', () => {
+  const uploadRouter = require('../routes/uploadRouter');
+  const layer = uploadRouter.stack.find(l => l.route && l.route.path === '/events');
+  expect(layer).toBeDefined();
+  const firstMiddleware = layer.route.stack[0].handle;
+  expect(firstMiddleware).toBe(defaultRateLimiter);
+});


### PR DESCRIPTION
## Summary
- add defaultRateLimiter to events endpoint
- test that `/events` route applies rate limiter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f453593c8333ad8f718d318aef63