### PR TITLE
Replace server console logs with logger

### DIFF
--- a/routes/uploadRouter.js
+++ b/routes/uploadRouter.js
@@ -61,26 +61,26 @@ setInterval(() => {
   clients.forEach((client, id) => {
     if (client.writableEnded || client.finished) {
       clients.delete(id);
-      console.log(`Pruned client ${id}, total clients: ${clients.size}`);
+      logger.info(`Pruned client ${id}, total clients: ${clients.size}`);
     }
   });
 }, 30000);
 
 // SSE route
 router.get('/events', (req, res) => {
-  console.log('New SSE client connected');
+  logger.info('New SSE client connected');
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
 
   const clientId = Date.now();
   clients.set(clientId, res);
-  console.log(`Client ${clientId} connected, total clients: ${clients.size}`);
+  logger.info(`Client ${clientId} connected, total clients: ${clients.size}`);
 
   res.on('error', (err) => {
-    console.error(`SSE stream error for client ${clientId}:`, err);
+    logger.error(`SSE stream error for client ${clientId}:`, err);
     clients.delete(clientId);
-    console.log(`Total clients after error: ${clients.size}`);
+    logger.info(`Total clients after error: ${clients.size}`);
   });
 
   // Send a test event to confirm connection and include queue status
@@ -95,31 +95,31 @@ router.get('/events', (req, res) => {
       }
     })}\n\n`);
   }).catch(err => {
-    console.error('Error retrieving queued jobs for SSE:', err);
+    logger.error('Error retrieving queued jobs for SSE:', err);
   });
 
   req.on('close', () => {
-    console.log(`Client ${clientId} disconnected`);
+    logger.info(`Client ${clientId} disconnected`);
     clients.delete(clientId);
-    console.log(`Total clients after disconnect: ${clients.size}`);
+    logger.info(`Total clients after disconnect: ${clients.size}`);
   });
 });
 
 // Function to send events to clients
 function sendEvent(message) {
-  console.log(`Sending SSE event to ${clients.size} clients:`, message);
+  logger.info(`Sending SSE event to ${clients.size} clients:`, message);
   clients.forEach((client, id) => {
     if (client.writableEnded || client.finished) {
       clients.delete(id);
-      console.log(`Removed ended SSE client ${id}, total clients: ${clients.size}`);
+      logger.info(`Removed ended SSE client ${id}, total clients: ${clients.size}`);
       return;
     }
     try {
       client.write(`data: ${JSON.stringify(message)}\n\n`);
     } catch (error) {
-      console.error('Error sending SSE event:', error);
+      logger.error('Error sending SSE event:', error);
       clients.delete(id);
-      console.log(`Total clients after write error: ${clients.size}`);
+      logger.info(`Total clients after write error: ${clients.size}`);
     }
   });
 }

--- a/services/schedulerService.js
+++ b/services/schedulerService.js
@@ -89,14 +89,12 @@ async function runJobInline(jobId, emitter) {
   const scriptPath = process.env.SEARCH_SCRIPT_PATH;
   const uploadDir = job.upload_dir;
   const proc = spawn(scriptPath, [uploadDir], { shell: false });
-  console.log('mock spawn called');
   let output = '';
   proc.stdout.on('data', d => { output += d.toString(); });
   proc.stderr.on('data', d => { output += d.toString(); });
   await new Promise((resolve, reject) => {
     proc.on('close', code => {
       if (code !== 0) return reject(new Error('Script failed'));
-      console.log('mock spawn close');
       logger.info(`runJobInline close for ${jobId}`);
       resolve();
     });


### PR DESCRIPTION
## Summary
- use logger for SSE event stream debug logs
- drop console.log statements from schedulerService test mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f61bd3a4833380743b6be284b746