### PR TITLE
Add APP_URL environment variable usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 
 # Application URL and server port
-APP_URL=http://localhost
+APP_URL=http://localhost  # Base URL used to build links
 PORT=443
 
 # Set to 'false' to disable HTTPS and start the server over HTTP

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ requires **Node.js 18** or later:
    Create a `.env` file in the root directory with the following variables:
    ```
    PORT=3000
-   APP_URL=http://localhost:3000
+   APP_URL=http://localhost:3000  # Base URL used to build links in the UI
    DATABASE_URL=postgres://username:password@localhost:5432/bgcatlas
    REDIS_HOST=127.0.0.1  # Redis host for Bull queue
    REDIS_PORT=6379       # Redis port for Bull queue

--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ const monthlySoilRouter = require('./routes/monthlySoilRouter');
 const jobRouter = require('./routes/jobRouter');
 
 const app = express();
+app.locals.APP_URL = process.env.APP_URL || '';
 app.use(compression()); // Add compression middleware for faster JSON responses
 app.use(etagMiddleware);
 app.use(cookieParser());

--- a/public/javascripts/bgcs.js
+++ b/public/javascripts/bgcs.js
@@ -505,11 +505,12 @@ function drawTable() {
                 biomeCell.html(biomeCell.html().replaceAll('root:', ''));
                 var assemblyCell = $(row).find('td').eq(1);
                 var assemblyID = assemblyCell.html();
-                assemblyCell.html('<a href="https://bgc-atlas.cs.uni-tuebingen.de/antismash?dataset=' + assemblyCell.html() + '" target="_blank">' + assemblyCell.html() + '</a>');
+                var base = (window.APP_URL || '');
+                assemblyCell.html('<a href="' + base + '/antismash?dataset=' + assemblyCell.html() + '" target="_blank">' + assemblyCell.html() + '</a>');
 
                 // assemblyCell.html('<a href="https://bgc-atlas.ziemertlab.com/datasets/' + assemblyCell.html() + '/antismash/index.html" target="_blank">' + assemblyCell.html() + '</a>');
                 var bgcCell = $(row).find('td').eq(0);
-                bgcCell.html('<a href="https://bgc-atlas.cs.uni-tuebingen.de/antismash?dataset=' + assemblyID + '&anchor=' + data.anchor + '" target="_blank">' + bgcCell.html() + '</a>');
+                bgcCell.html('<a href="' + base + '/antismash?dataset=' + assemblyID + '&anchor=' + data.anchor + '" target="_blank">' + bgcCell.html() + '</a>');
 
                 //bgcCell.html('<a href="https://bgc-atlas.ziemertlab.com/datasets/' + data.assembly + '/antismash/index.html#' + data.anchor + '" target="_blank">' + bgcCell.html() + '</a>');
                 var gcfCell = $(row).find('td').eq(7);

--- a/public/javascripts/job_status_polling.js
+++ b/public/javascripts/job_status_polling.js
@@ -26,7 +26,8 @@
         nameCell.textContent = item.bgc_name;
 
         const gcfLink = document.createElement('a');
-        gcfLink.href = `https://bgc-atlas.cs.uni-tuebingen.de/bgcs?gcf=${item.gcf_id}`;
+        const base = (window.APP_URL || '');
+        gcfLink.href = `${base}/bgcs?gcf=${item.gcf_id}`;
         gcfLink.textContent = item.gcf_id;
         gcfLink.target = '_blank';
         idCell.appendChild(gcfLink);

--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -104,7 +104,7 @@ function createMap() {
             L.DomEvent.on(btn, 'click', function() {
                 if (containedIDs.length > 0) {
                     // Construct the URL with the sample IDs
-                    var baseUrl = 'https://bgc-atlas.cs.uni-tuebingen.de/bgcs?samples=';
+                    var baseUrl = (window.APP_URL || '') + '/bgcs?samples=';
                     var sampleIdsParam = containedIDs.join(','); // Join the IDs with commas
                     var fullUrl = baseUrl + encodeURIComponent(sampleIdsParam);
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -11,15 +11,15 @@ html(lang="en")
         meta(name='robots', content='index, follow')
         meta(property='og:type', content='Website')
         meta(property='og:title', content=title || 'BGC Atlas')
-        meta(property='og:url', content='https://bgc-atlas.cs.uni-tuebingen.de')
+        meta(property='og:url', content=APP_URL)
         meta(property='og:description', content=metaDescription || "Biosynthetic Gene Cluster Atlas")
-        meta(property='og:image', content='https://bgc-atlas.cs.uni-tuebingen.de/images/BGC-Atlas-logo.png')
+        meta(property='og:image', content=APP_URL + '/images/BGC-Atlas-logo.png')
         meta(property='og:image:alt', content='BGC Atlas Logo')
         meta(property='og:locale', content='en_US')
         meta(name='twitter:card', content='summary_large_image')
         meta(name='twitter:title', content=title || 'BGC Atlas')
         meta(name='twitter:description', content=metaDescription || "Biosynthetic Gene Cluster Atlas")
-        meta(name='twitter:image', content='https://bgc-atlas.cs.uni-tuebingen.de/images/BGC-Atlas-logo.png')
+        meta(name='twitter:image', content=APP_URL + '/images/BGC-Atlas-logo.png')
         title #{title ? `${title} | BGC Atlas` : 'BGC Atlas'}
         link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css")
         link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css")
@@ -39,6 +39,9 @@ html(lang="en")
             div.content-container
                 block content
             +footer()
+
+        script.
+            window.APP_URL = '!{APP_URL}'
 
         block scripts
 


### PR DESCRIPTION
## Summary
- expose `APP_URL` via `app.locals` and make it accessible in layout
- update layout meta tags and provide global `APP_URL` JS variable
- build links from `APP_URL` in map.js, bgcs.js and job_status_polling.js
- document `APP_URL` in README and `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f61f29cc8333b3419bbba631a5fe