### PR TITLE
Add env validation for DB config

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -4,7 +4,6 @@
  * Module dependencies.
  */
 
-var app = require('../app');
 var debug = require('debug')('worldbgcatlasweb:server');
 var http = require('http');
 
@@ -13,6 +12,14 @@ var fs = require('fs');
 var path = require('path');
 var { validateSSLCertPath, validateRequiredPaths } = require('../utils/pathValidator');
 var logger = require('../utils/logger');
+
+let app;
+try {
+  app = require('../app');
+} catch (err) {
+  logger.error(err.message);
+  process.exit(1);
+}
 
 
 const enableSSL = process.env.ENABLE_SSL !== 'false';

--- a/config/database.js
+++ b/config/database.js
@@ -1,5 +1,12 @@
 require('dotenv').config();
 
+const requiredVars = ['DB_USER', 'DB_HOST', 'DB_DATABASE', 'DB_PASSWORD'];
+const missingVars = requiredVars.filter(v => !process.env[v]);
+if (missingVars.length) {
+    const plural = missingVars.length > 1 ? 's' : '';
+    throw new Error(`Missing required database environment variable${plural}: ${missingVars.join(', ')}`);
+}
+
 const { Pool } = require('pg');
 
 // Create a PostgreSQL pool for multiple connections

--- a/tests/databaseConfig.test.js
+++ b/tests/databaseConfig.test.js
@@ -1,0 +1,25 @@
+describe('database config environment validation', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  it('throws when required env vars are missing', () => {
+    process.env = { ...originalEnv };
+    delete process.env.DB_USER;
+    delete process.env.DB_HOST;
+    delete process.env.DB_DATABASE;
+    delete process.env.DB_PASSWORD;
+
+    jest.mock('pg', () => ({ Pool: jest.fn(() => ({})) }));
+    expect(() => require('../config/database')).toThrow('Missing required database environment variable');
+  });
+
+  it('does not throw when all env vars are set', () => {
+    process.env = { ...originalEnv, DB_USER: 'u', DB_HOST: 'h', DB_DATABASE: 'd', DB_PASSWORD: 'p' };
+    jest.mock('pg', () => ({ Pool: jest.fn(() => ({})) }));
+    expect(() => require('../config/database')).not.toThrow();
+  });
+});

--- a/tests/schedulerService.test.js
+++ b/tests/schedulerService.test.js
@@ -10,6 +10,7 @@ const mockQueue = {
 };
 
 jest.mock('bull', () => jest.fn().mockImplementation(() => mockQueue));
+jest.mock('../config/database', () => ({ pool: { query: jest.fn() } }));
 
 const originalEnv = process.env.NODE_ENV;
 let schedulerService;

--- a/tests/searchService.test.js
+++ b/tests/searchService.test.js
@@ -8,6 +8,8 @@ jest.mock('child_process', () => ({
   }))
 }));
 
+jest.mock('../config/database', () => ({ pool: { query: jest.fn() } }));
+
 // Import the required modules
 const { sanitizeDirectoryName, getMembership } = require('../services/searchService');
 const { spawn } = require('child_process');

--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events');
 const fs = require('fs-extra');
 const path = require('path');
 const { spawn } = require('child_process');
+jest.mock('../config/database', () => ({ pool: { query: jest.fn() } }));
 const jobService = require('../services/jobService');
 
 jest.mock('fs-extra', () => {


### PR DESCRIPTION
## Summary
- validate required database environment variables in `config/database.js`
- handle app startup failures in `bin/www`
- mock database module in tests and add new database config tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f647052883338e1643db191c501f