### PR TITLE
Use streams for GenBank file validation

### DIFF
--- a/tests/searchService.upload.test.js
+++ b/tests/searchService.upload.test.js
@@ -44,7 +44,7 @@ describe('validateUploadedFiles', () => {
     const tmpDir = fs.mkdtempSync('/tmp/gbk-');
     const filePath = path.join(tmpDir, 'test.gbk');
     fs.writeFileSync(filePath, 'LOCUS       TEST');
-    await expect(validateUploadedFiles([{ path: filePath }])).resolves.not.toThrow();
+    await expect(validateUploadedFiles([{ path: filePath }])).resolves.toBeUndefined();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary
- refactor `validateUploadedFiles` to use `createReadStream` instead of `fs.promises.open`
- update unit test to expect resolved `undefined`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f6784cbc833395aac1e71116337d