### PR TITLE
Add noopener to map link

### DIFF
--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -109,8 +109,8 @@ function createMap() {
                     var sampleIdsParam = containedIDs.join(','); // Join the IDs with commas
                     var fullUrl = baseUrl + encodeURIComponent(sampleIdsParam);
 
-                    // Open the URL in a new tab or redirect
-                    window.open(fullUrl, '_blank'); // Opens in a new tab
+                    // Open the URL in a new tab using "noopener" for security
+                    window.open(fullUrl, '_blank', 'noopener'); // Opens in a new tab
                     // Alternatively, you can use window.location.href = fullUrl; to redirect in the same tab
                 } else {
                     alert("Please use the rectangle tool on the left-side to select a region for inspection.");


### PR DESCRIPTION
## Summary
- open new map tab securely by passing `noopener`

## Testing
- `DB_USER=u DB_HOST=h DB_DATABASE=d DB_PASSWORD=p NODE_ENV=test npm test` *(fails: TypeError next is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841fca9eadc8333a173cb9bf1b21376