### PR TITLE
Implement SSE client cleanup timer

### DIFF
--- a/tests/uploadRouter.events.test.js
+++ b/tests/uploadRouter.events.test.js
@@ -1,18 +1,44 @@
-const { defaultRateLimiter } = require('../services/rateLimitMiddleware');
+let defaultRateLimiter;
 
-// Use fake timers to prevent the interval in uploadRouter from running
-beforeAll(() => {
-  jest.useFakeTimers();
-});
+describe('uploadRouter events', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    ({ defaultRateLimiter } = require('../services/rateLimitMiddleware'));
+  });
 
-afterAll(() => {
-  jest.useRealTimers();
-});
+  afterEach(() => {
+    const uploadRouter = require('../routes/uploadRouter');
+    uploadRouter._stopClientCleanupTimer();
+    uploadRouter._clients.clear();
+    jest.useRealTimers();
+  });
 
-test('events endpoint is protected by defaultRateLimiter', () => {
-  const uploadRouter = require('../routes/uploadRouter');
-  const layer = uploadRouter.stack.find(l => l.route && l.route.path === '/events');
-  expect(layer).toBeDefined();
-  const firstMiddleware = layer.route.stack[0].handle;
-  expect(firstMiddleware).toBe(defaultRateLimiter);
+  test('events endpoint is protected by defaultRateLimiter', () => {
+    const uploadRouter = require('../routes/uploadRouter');
+    const layer = uploadRouter.stack.find(l => l.route && l.route.path === '/events');
+    expect(layer).toBeDefined();
+    const firstMiddleware = layer.route.stack[0].handle;
+    expect(firstMiddleware).toBe(defaultRateLimiter);
+  });
+
+  test('cleanup timer removes inactive clients', () => {
+    const uploadRouter = require('../routes/uploadRouter');
+    const handler = uploadRouter.stack.find(l => l.route && l.route.path === '/events').route.stack[1].handle;
+    const EventEmitter = require('events');
+    const req = new EventEmitter();
+    const res = new EventEmitter();
+    res.setHeader = jest.fn();
+    res.write = jest.fn();
+
+    handler(req, res);
+
+    expect(uploadRouter._clients.size).toBe(1);
+
+    res.finished = true;
+
+    jest.advanceTimersByTime(30000);
+
+    expect(uploadRouter._clients.size).toBe(0);
+  });
 });

--- a/tests/uploadRouter.test.js
+++ b/tests/uploadRouter.test.js
@@ -137,7 +137,7 @@ describe('SSE client cleanup', () => {
   let handler;
 
   beforeAll(() => {
-    handler = router.stack.find(l => l.route && l.route.path === '/events').route.stack[0].handle;
+    handler = router.stack.find(l => l.route && l.route.path === '/events').route.stack[1].handle;
   });
 
   beforeEach(() => {
@@ -173,4 +173,8 @@ describe('SSE client cleanup', () => {
 
     expect(router._clients.size).toBe(0);
   });
+});
+
+afterAll(() => {
+  router._stopClientCleanupTimer();
 });


### PR DESCRIPTION
## Summary
- add a periodic timer to purge inactive SSE clients
- expose control functions for testing
- use the SSE handler directly in upload router tests
- test timer-driven cleanup with fake timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fca1e24483338306d76b355ea4fa