### PR TITLE
Use sqlite3 package for membership query

### DIFF
--- a/tests/uploadRouter.test.js
+++ b/tests/uploadRouter.test.js
@@ -137,7 +137,8 @@ describe('SSE client cleanup', () => {
   let handler;
 
   beforeAll(() => {
-    handler = router.stack.find(l => l.route && l.route.path === '/events').route.stack[0].handle;
+    const eventsRoute = router.stack.find(l => l.route && l.route.path === '/events');
+    handler = eventsRoute.route.stack[1].handle; // skip rate limiter middleware
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- remove child_process spawn usage in searchService
- query SQLite via `sqlite3` driver
- adjust tests for new sqlite logic
- fix SSE client test middleware index

## Testing
- `DB_USER=a DB_HOST=localhost DB_DATABASE=d DB_PASSWORD=p DB_PORT=5432 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fc958edc833382654f51196a4ba5